### PR TITLE
Ensure main runs in scale-workloads

### DIFF
--- a/k8s-scripts/workload-management/scale-workloads.sh
+++ b/k8s-scripts/workload-management/scale-workloads.sh
@@ -1352,3 +1352,6 @@ main() {
   format-echo "SUCCESS" "Workload scaling completed."
   print_with_separator
 }
+
+# Execute the main function when the script is run
+main "$@"


### PR DESCRIPTION
## Summary
- run `main` automatically when executing `scale-workloads.sh`

## Testing
- `bash -n k8s-scripts/workload-management/scale-workloads.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d54da8b5c83259a67f7081920f2a9