### PR TITLE
Add strict error handling

### DIFF
--- a/k8s-scripts/cluster-maintenance/clean-cluster.sh
+++ b/k8s-scripts/cluster-maintenance/clean-cluster.sh
@@ -2,6 +2,8 @@
 # clean-cluster.sh
 # Script to reset a Kubernetes cluster to a clean state by removing non-system workloads
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-maintenance/convert-cluster.sh
+++ b/k8s-scripts/cluster-maintenance/convert-cluster.sh
@@ -2,6 +2,8 @@
 # convert-cluster.sh
 # Script to convert/migrate between Kubernetes cluster providers
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-maintenance/rotate-certs.sh
+++ b/k8s-scripts/cluster-maintenance/rotate-certs.sh
@@ -2,6 +2,8 @@
 # rotate-certs.sh
 # Script to rotate Kubernetes cluster certificates before expiration
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-configuration-management/export-kubeconfig.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/export-kubeconfig.sh
@@ -2,6 +2,8 @@
 # export-kubeconfig.sh
 # Script to export kubeconfig from Kubernetes clusters for sharing
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-configuration-management/merge-kubeconfig.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/merge-kubeconfig.sh
@@ -2,6 +2,8 @@
 # merge-kubeconfig.sh
 # Script to merge multiple kubeconfig files into a single file
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-state-management/delete-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/delete-cluster-local.sh
@@ -2,6 +2,8 @@
 # delete-cluster.sh
 # Script to delete Kubernetes clusters from various providers
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
@@ -2,6 +2,8 @@
 # pause-cluster.sh
 # Script to temporarily pause/hibernate Kubernetes clusters to save resources
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-state-management/restart-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/restart-cluster-local.sh
@@ -2,6 +2,8 @@
 # restart-cluster.sh
 # Script to restart Kubernetes clusters across various providers
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-state-management/resume-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/resume-cluster-local.sh
@@ -2,6 +2,8 @@
 # resume-cluster.sh
 # Script to resume paused Kubernetes clusters with additional validation
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-management/list-clusters.sh
+++ b/k8s-scripts/cluster-management/list-clusters.sh
@@ -2,6 +2,8 @@
 # list-clusters.sh
 # Script to list all Kubernetes clusters across various providers, both local and cloud
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-management/scale-cluster-local.sh
+++ b/k8s-scripts/cluster-management/scale-cluster-local.sh
@@ -2,6 +2,8 @@
 # scale-cluster-local.sh
 # Script to scale Kubernetes clusters by changing the number of nodes
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-management/switch-context.sh
+++ b/k8s-scripts/cluster-management/switch-context.sh
@@ -2,6 +2,8 @@
 # switch-context.sh
 # Script to easily switch between Kubernetes contexts
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/cluster-management/upgrade-cluster-local.sh
+++ b/k8s-scripts/cluster-management/upgrade-cluster-local.sh
@@ -2,6 +2,8 @@
 # upgrade-cluster-local.sh
 # Script to upgrade Kubernetes clusters across various providers
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/node-management/drain-nodes.sh
+++ b/k8s-scripts/node-management/drain-nodes.sh
@@ -2,6 +2,8 @@
 # drain-nodes.sh
 # Script to safely cordon and drain Kubernetes nodes for maintenance
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/node-management/label-nodes.sh
+++ b/k8s-scripts/node-management/label-nodes.sh
@@ -2,6 +2,8 @@
 # label-nodes.sh
 # Script to manage Kubernetes node labels with batch operations and templates
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/k8s-scripts/node-management/taint-nodes.sh
+++ b/k8s-scripts/node-management/taint-nodes.sh
@@ -2,6 +2,8 @@
 # taint-nodes.sh
 # Script to manage Kubernetes node taints with batch operations and presets
 
+set -euo pipefail
+
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================

--- a/security-and-access/unused_ssh_key_detector.sh
+++ b/security-and-access/unused_ssh_key_detector.sh
@@ -2,7 +2,7 @@
 # unused_ssh_key_detector.sh
 # Script to detect unused SSH keys and suggest remediation actions.
 
-set -eo pipefail
+set -euo pipefail
 
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES


### PR DESCRIPTION
## Summary
- add `set -euo pipefail` to `unused_ssh_key_detector.sh`
- enforce strict error handling across Kubernetes helper scripts

## Testing
- `grep -L "set -euo pipefail" -r k8s-scripts`

------
https://chatgpt.com/codex/tasks/task_e_686d54df19a88325825039e42383070f