### PR TITLE
Standardize shebangs to /usr/bin/env bash

### DIFF
--- a/development-and-code-managment/dependecies-updater/dependency-updater-npm.sh
+++ b/development-and-code-managment/dependecies-updater/dependency-updater-npm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # dependency-updater-npm.sh
 # Script to update npm dependencies and generate a summary of updated packages
 

--- a/development-and-code-managment/dependecies-updater/dependency-updater-python.sh
+++ b/development-and-code-managment/dependecies-updater/dependency-updater-python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # dependency-updater-python.sh
 # Script to update Python dependencies listed in a requirements file
 

--- a/development-and-code-managment/git/generate-changelog.sh
+++ b/development-and-code-managment/git/generate-changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # generate-changelog.sh
 # Script to generate a changelog from the Git log
 

--- a/development-and-code-managment/git/git-add-commit-push.sh
+++ b/development-and-code-managment/git/git-add-commit-push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # git-add-commit-push.sh
 # Script to automate Git operations: add, commit, and push
 

--- a/development-and-code-managment/git/git-commit-validator.sh
+++ b/development-and-code-managment/git/git-commit-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # git-commit-validator.sh
 # Script to validate and commit changes with a proper commit message
 

--- a/development-and-code-managment/git/git-conflict-finder.sh
+++ b/development-and-code-managment/git/git-conflict-finder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # git-conflict-finder.sh
 # Script to find merge conflicts in a Git repository
 

--- a/development-and-code-managment/git/git-stash-manager.sh
+++ b/development-and-code-managment/git/git-stash-manager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # git-stash-manager.sh
 # Script to manage Git stashes (list, apply, drop)
 

--- a/file-scripts/add-prefix-to-files.sh
+++ b/file-scripts/add-prefix-to-files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # add-prefix-to-files.sh
 # Script to add a prefix to all files in a specified directory
 

--- a/file-scripts/clean-old-files.sh
+++ b/file-scripts/clean-old-files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # clean-old-files.sh
 # Script to delete files older than a specified number of days
 

--- a/file-scripts/compare-files.sh
+++ b/file-scripts/compare-files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # compare-files.sh
 # Script to compare two files and print differences
 

--- a/file-scripts/compress-tar-directory.sh
+++ b/file-scripts/compress-tar-directory.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # compress-tar-directory.sh
 # Script to compress a directory into a tar.gz file
 

--- a/file-scripts/count-files.sh
+++ b/file-scripts/count-files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # count-files.sh
 # Script to count the number of files and directories in a given path
 

--- a/file-scripts/create-symlink.sh
+++ b/file-scripts/create-symlink.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # create-symlink.sh
 # Script to create a symbolic link
 

--- a/file-scripts/create-zip.sh
+++ b/file-scripts/create-zip.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # create-zip.sh
 # Script to create a zip archive of a directory or file
 

--- a/file-scripts/download-file.sh
+++ b/file-scripts/download-file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # download-file.sh
 # Script to download a file using curl
 

--- a/file-scripts/extract-tar.sh
+++ b/file-scripts/extract-tar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # extract-tar.sh
 # Script to extract a tar archive
 

--- a/file-scripts/extract-zip.sh
+++ b/file-scripts/extract-zip.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # extract-zip.sh
 # Script to extract a zip archive
 

--- a/file-scripts/find-large-files.sh
+++ b/file-scripts/find-large-files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # find-large-files.sh
 # Script to find and list files larger than a specified size
 

--- a/file-scripts/sync-directories.sh
+++ b/file-scripts/sync-directories.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # sync-directories.sh
 # Script to synchronize two directories using rsync
 

--- a/functions/format-echo/format-echo.sh
+++ b/functions/format-echo/format-echo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Utility script to log messages with log levels, timestamps, and optional file logging.
 
 # Function to log messages with log levels and timestamps

--- a/functions/print-functions/print-with-separator.sh
+++ b/functions/print-functions/print-with-separator.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Function to print a message with separators to both terminal and log file
 print_with_separator() {
   local MESSAGE="${1:-}"

--- a/k8s-scripts/cluster-maintenance/clean-cluster.sh
+++ b/k8s-scripts/cluster-maintenance/clean-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # clean-cluster.sh
 # Script to reset a Kubernetes cluster to a clean state by removing non-system workloads
 

--- a/k8s-scripts/cluster-maintenance/convert-cluster.sh
+++ b/k8s-scripts/cluster-maintenance/convert-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # convert-cluster.sh
 # Script to convert/migrate between Kubernetes cluster providers
 

--- a/k8s-scripts/cluster-maintenance/rotate-certs.sh
+++ b/k8s-scripts/cluster-maintenance/rotate-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # rotate-certs.sh
 # Script to rotate Kubernetes cluster certificates before expiration
 

--- a/k8s-scripts/cluster-management/cluster-configuration-management/apply-k8s-configuration.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/apply-k8s-configuration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # apply-k8s-configuration.sh
 # Script to apply Kubernetes manifests in order (no cluster creation)
 

--- a/k8s-scripts/cluster-management/cluster-configuration-management/export-kubeconfig.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/export-kubeconfig.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # export-kubeconfig.sh
 # Script to export kubeconfig from Kubernetes clusters for sharing
 

--- a/k8s-scripts/cluster-management/cluster-configuration-management/merge-kubeconfig.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/merge-kubeconfig.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # merge-kubeconfig.sh
 # Script to merge multiple kubeconfig files into a single file
 

--- a/k8s-scripts/cluster-management/cluster-state-management/create-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/create-cluster-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # create-cluster-local.sh
 # Script to create Kubernetes clusters with various providers
 

--- a/k8s-scripts/cluster-management/cluster-state-management/delete-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/delete-cluster-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # delete-cluster.sh
 # Script to delete Kubernetes clusters from various providers
 

--- a/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # pause-cluster.sh
 # Script to temporarily pause/hibernate Kubernetes clusters to save resources
 

--- a/k8s-scripts/cluster-management/cluster-state-management/restart-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/restart-cluster-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # restart-cluster.sh
 # Script to restart Kubernetes clusters across various providers
 

--- a/k8s-scripts/cluster-management/cluster-state-management/resume-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/resume-cluster-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # resume-cluster.sh
 # Script to resume paused Kubernetes clusters with additional validation
 

--- a/k8s-scripts/cluster-management/list-clusters.sh
+++ b/k8s-scripts/cluster-management/list-clusters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # list-clusters.sh
 # Script to list all Kubernetes clusters across various providers, both local and cloud
 

--- a/k8s-scripts/cluster-management/scale-cluster-local.sh
+++ b/k8s-scripts/cluster-management/scale-cluster-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # scale-cluster-local.sh
 # Script to scale Kubernetes clusters by changing the number of nodes
 

--- a/k8s-scripts/cluster-management/switch-context.sh
+++ b/k8s-scripts/cluster-management/switch-context.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # switch-context.sh
 # Script to easily switch between Kubernetes contexts
 

--- a/k8s-scripts/cluster-management/upgrade-cluster-local.sh
+++ b/k8s-scripts/cluster-management/upgrade-cluster-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # upgrade-cluster-local.sh
 # Script to upgrade Kubernetes clusters across various providers
 

--- a/k8s-scripts/image-management/build-and-load-images.sh
+++ b/k8s-scripts/image-management/build-and-load-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # build-and-load-images.sh
 # Build Docker images and load them into a local Kubernetes cluster (minikube, kind, or k3d)
 

--- a/k8s-scripts/image-management/k8s-registry-pipeline.sh
+++ b/k8s-scripts/image-management/k8s-registry-pipeline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # k8s-registry-pipeline.sh
 # Simplified script to set up a Docker registry and push images to it.
 

--- a/k8s-scripts/node-management/drain-nodes.sh
+++ b/k8s-scripts/node-management/drain-nodes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # drain-nodes.sh
 # Script to safely cordon and drain Kubernetes nodes for maintenance
 

--- a/k8s-scripts/node-management/label-nodes.sh
+++ b/k8s-scripts/node-management/label-nodes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # label-nodes.sh
 # Script to manage Kubernetes node labels with batch operations and templates
 

--- a/k8s-scripts/node-management/taint-nodes.sh
+++ b/k8s-scripts/node-management/taint-nodes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # taint-nodes.sh
 # Script to manage Kubernetes node taints with batch operations and presets
 

--- a/k8s-scripts/pipelines/create-cluster-build-load-apply.sh
+++ b/k8s-scripts/pipelines/create-cluster-build-load-apply.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # create-cluster-build-load-apply.sh
 # Script to create a cluster, build/load images into the cluster, and apply manifests if files are given.
 

--- a/k8s-scripts/workload-management/scale-workloads.sh
+++ b/k8s-scripts/workload-management/scale-workloads.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # scale-workloads.sh
 # Script to intelligently scale Kubernetes workloads based on metrics or schedules
 

--- a/network-and-connectivity/active-host-scanner.sh
+++ b/network-and-connectivity/active-host-scanner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # active-host-scanner.sh
 # Script to scan a network for active hosts
 

--- a/network-and-connectivity/arp-table-viewer.sh
+++ b/network-and-connectivity/arp-table-viewer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # arp-table-viewer.sh
 # Script to view and log the ARP table
 

--- a/network-and-connectivity/bandwith-monitor.sh
+++ b/network-and-connectivity/bandwith-monitor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # bandwidth-monitor.sh
 # Script to monitor bandwidth usage on a specified network interface
 

--- a/network-and-connectivity/dns-resolver.sh
+++ b/network-and-connectivity/dns-resolver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # dns-resolver.sh
 # Script to test DNS resolution for a list of domains
 

--- a/network-and-connectivity/http-status-code-checker.sh
+++ b/network-and-connectivity/http-status-code-checker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # http-status-code-checker.sh
 # Script to check HTTP status codes for a list of URLs
 

--- a/network-and-connectivity/ip-extractor-from-log-file.sh
+++ b/network-and-connectivity/ip-extractor-from-log-file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ip-extractor-from-log-file.sh
 # Script to extract unique IP addresses from a log file
 

--- a/network-and-connectivity/network-speed-test.sh
+++ b/network-and-connectivity/network-speed-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # network-speed-test.sh
 # Script to run a network speed test using speedtest-cli
 

--- a/network-and-connectivity/ping.sh
+++ b/network-and-connectivity/ping.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ping.sh
 # Script to ping a list of servers/websites and check their reachability
 

--- a/network-and-connectivity/port-scanner.sh
+++ b/network-and-connectivity/port-scanner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # port-scanner.sh
 # Script to scan open ports on a specified server
 

--- a/security-and-access/firewall_configurator.sh
+++ b/security-and-access/firewall_configurator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # firewall_configurator.sh
 # Script to configure basic firewall rules using UFW.
 

--- a/security-and-access/group_access_auditor.sh
+++ b/security-and-access/group_access_auditor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # group_access_auditor.sh
 # Script to audit groups and user memberships on the system.
 

--- a/security-and-access/malware_scanner.sh
+++ b/security-and-access/malware_scanner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # malware_scanner.sh
 # Script to scan directories for suspicious files and potential malware.
 

--- a/security-and-access/password_generator.sh
+++ b/security-and-access/password_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # filepath: /Users/mykfor1/Documents/git/github/shell-scripts/security-and-access/password_generator.sh
 # Advanced script to generate strong, random passwords with various options.
 

--- a/security-and-access/secure_file_permissions.sh
+++ b/security-and-access/secure_file_permissions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # filepath: /Users/mykfor1/Documents/git/github/shell-scripts/security-and-access/secure_file_permissions.sh
 # Script to set secure permissions for sensitive files.
 

--- a/security-and-access/ssh_key_manager.sh
+++ b/security-and-access/ssh_key_manager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # filepath: /Users/mykfor1/Documents/git/github/shell-scripts/security-and-access/ssh_key_manager.sh
 # Script to generate, manage and distribute SSH keys with advanced features.
 

--- a/security-and-access/unused_ssh_key_detector.sh
+++ b/security-and-access/unused_ssh_key_detector.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # unused_ssh_key_detector.sh
 # Script to detect unused SSH keys and suggest remediation actions.
 

--- a/security-and-access/user_access_auditor.sh
+++ b/security-and-access/user_access_auditor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # user_access_auditor.sh
 # Script to audit user access and log the results.
 

--- a/shell-scripts.sh
+++ b/shell-scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shell-scripts.sh
 # A wrapper script to manage and execute all shell scripts in the same directory as this script
 

--- a/system-scripts/check-process.sh
+++ b/system-scripts/check-process.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check-process.sh
 # Script to check if a specific process is running.
 

--- a/system-scripts/check-updates.sh
+++ b/system-scripts/check-updates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check-updates.sh
 # Script to check for and install system updates.
 

--- a/system-scripts/cpu-monitor.sh
+++ b/system-scripts/cpu-monitor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # cpu-monitor.sh
 # Script to monitor CPU usage and alert if it exceeds a threshold.
 

--- a/system-scripts/disk-usage.sh
+++ b/system-scripts/disk-usage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # disk-usage.sh
 # Script to check disk usage and alert if it exceeds a threshold.
 

--- a/system-scripts/monitor-network.sh
+++ b/system-scripts/monitor-network.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # monitor-network.sh
 # Script to monitor network traffic on a specified interface or Docker container.
 

--- a/system-scripts/monitor-resources.sh
+++ b/system-scripts/monitor-resources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # monitor-resources.sh
 # Script to monitor system resources (CPU, memory, disk) and log the usage.
 

--- a/system-scripts/schedule-task.sh
+++ b/system-scripts/schedule-task.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # schedule-task.sh
 # Script to schedule a task using cron or launchd (on macOS).
 

--- a/system-scripts/system-report.sh
+++ b/system-scripts/system-report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # system-report.sh
 # Script to generate a comprehensive system report.
 

--- a/utils/docker-utils/docker-cleanup.sh
+++ b/utils/docker-utils/docker-cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # docker-cleanup.sh
 # Script to clean up all Docker containers, images, volumes, and networks.
 

--- a/utils/docker-utils/docker-info.sh
+++ b/utils/docker-utils/docker-info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # docker-info.sh
 # Script to show detailed information about Docker containers, images, volumes, and networks.
 

--- a/utils/docker-utils/inspect-resource-docker.sh
+++ b/utils/docker-utils/inspect-resource-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # inspect-resource-docker.sh
 # Script to inspect Docker resources (containers, networks, volumes).
 

--- a/utils/docker-utils/real_time_container_logs.sh
+++ b/utils/docker-utils/real_time_container_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # real_time_container_logs.sh
 # Script to follow logs of a specified Docker container in real-time.
 

--- a/utils/docker-utils/start-docker-compose-in-tmux.sh
+++ b/utils/docker-utils/start-docker-compose-in-tmux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # start-docker-compose-in-tmux.sh
 # Script to start Docker Compose in a new tmux session.
 

--- a/utils/docker-utils/start-docker-containers.sh
+++ b/utils/docker-utils/start-docker-containers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # start-docker-containers.sh
 # Script to start multiple Docker containers in detached mode.
 

--- a/utils/docker-utils/stop_all_containers.sh
+++ b/utils/docker-utils/stop_all_containers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # stop_all_containers.sh
 # Script to stop all running Docker containers.
 

--- a/utils/docker-utils/view-container_logs.sh
+++ b/utils/docker-utils/view-container_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # view_container_logs.sh
 # Script to view logs of a specified Docker container with additional options.
 

--- a/utils/generate-ssh-key.sh
+++ b/utils/generate-ssh-key.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # generate-ssh-key.sh
 # Script to generate an SSH key pair.
 

--- a/utils/npm/npm-clean-cache.sh
+++ b/utils/npm/npm-clean-cache.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # npm-clean-cache.sh
 # Script to clean the NPM cache.
 

--- a/utils/npm/npm-list-global.sh
+++ b/utils/npm/npm-list-global.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # npm-list-global.sh
 # Script to list all globally installed NPM packages.
 

--- a/utils/npm/npm-update-all.sh
+++ b/utils/npm/npm-update-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # npm-update-all.sh
 # Script to update all NPM packages to the latest version.
 

--- a/utils/services-utils/backup-postgresql-compressed.sh
+++ b/utils/services-utils/backup-postgresql-compressed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # backup-postgresql-compressed.sh
 # Script to back up a PostgreSQL database and compress the backup.
 

--- a/utils/services-utils/backup-postgresql.sh
+++ b/utils/services-utils/backup-postgresql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # backup-postgresql.sh
 # Script to back up a PostgreSQL database.
 

--- a/utils/services-utils/restore-postgresql-compressed.sh
+++ b/utils/services-utils/restore-postgresql-compressed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # restore-postgresql-compressed.sh
 # Script to restore a PostgreSQL database from a compressed backup.
 

--- a/utils/services-utils/restore-postgresql.sh
+++ b/utils/services-utils/restore-postgresql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # restore-postgresql.sh
 # Script to restore a PostgreSQL database from a backup file.
 


### PR DESCRIPTION
## Summary
- standardize all shell scripts to use `#!/usr/bin/env bash`
- add missing shebang to `print-with-separator.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871304673a0832598a15c30e7b1ebbd