### PR TITLE
Update README with repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated collection of standalone shell scripts for system administration, deve
 
 ### Clone the repository
 ```bash
-git clone https://github.com/your-username/shell-scripts.git
+git clone https://github.com/MForofontov/shell-scripts.git
 cd shell-scripts
 ```
 


### PR DESCRIPTION
## Summary
- fix clone command URL in README

## Testing
- `bash -n` over all script files

------
https://chatgpt.com/codex/tasks/task_e_687a3ab5e66c8325bbe07f82e6a33eb9