### PR TITLE
Add shellcheck runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ cd shell-scripts
 chmod +x shell-scripts.sh */*.sh */*/*.sh
 ```
 
+### Lint scripts with shellcheck
+Run shellcheck on all scripts:
+```bash
+./utils/run-shellcheck.sh
+```
+If `shellcheck` is not installed, install it via your package manager (for example, `sudo apt-get install shellcheck`).
+
 ### Running a script
 List all available scripts:
 ```bash

--- a/utils/run-shellcheck.sh
+++ b/utils/run-shellcheck.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# run-shellcheck.sh
+# Script to run shellcheck on all .sh files in the repository
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+UTILITY_FILE="$REPO_ROOT/functions/utility.sh"
+
+if [ -f "$UTILITY_FILE" ]; then
+  # shellcheck source=functions/utility.sh
+  source "$UTILITY_FILE"
+else
+  command_exists() { command -v "$1" >/dev/null 2>&1; }
+fi
+
+if ! command_exists shellcheck; then
+  echo "shellcheck is not installed. Please install it and re-run this script." >&2
+  exit 1
+fi
+
+find "$REPO_ROOT" -type f -name '*.sh' -exec shellcheck "$@" {} +


### PR DESCRIPTION
## Summary
- add a helper script to run shellcheck on all scripts
- document shellcheck usage in the README

## Testing
- `./utils/run-shellcheck.sh` *(fails: shellcheck not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687fcb11a51883259bfbcc5abba286e0