### PR TITLE
Add setup_log_file utility and refactor scripts

### DIFF
--- a/development-and-code-management/dependencies-updater/dependency-updater-npm.sh
+++ b/development-and-code-management/dependencies-updater/dependency-updater-npm.sh
@@ -90,14 +90,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "NPM Dependency Updater Script"
   format-echo "INFO" "Starting NPM Dependency Updater Script..."

--- a/development-and-code-management/dependencies-updater/dependency-updater-python.sh
+++ b/development-and-code-management/dependencies-updater/dependency-updater-python.sh
@@ -95,14 +95,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Python Dependency Updater Script"
   format-echo "INFO" "Starting Python Dependency Updater Script..."

--- a/development-and-code-management/git/generate-changelog.sh
+++ b/development-and-code-management/git/generate-changelog.sh
@@ -95,14 +95,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Generate Changelog Script"
   format-echo "INFO" "Starting Generate Changelog Script..."

--- a/development-and-code-management/git/git-add-commit-push.sh
+++ b/development-and-code-management/git/git-add-commit-push.sh
@@ -94,14 +94,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Git Add, Commit, and Push Script"
   format-echo "INFO" "Starting Git Add, Commit, and Push Script..."

--- a/development-and-code-management/git/git-commit-validator.sh
+++ b/development-and-code-management/git/git-commit-validator.sh
@@ -94,14 +94,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Git Commit Validator Script"
   format-echo "INFO" "Starting Git Commit Validator Script..."

--- a/development-and-code-management/git/git-conflict-finder.sh
+++ b/development-and-code-management/git/git-conflict-finder.sh
@@ -87,14 +87,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Git Conflict Finder Script"
   format-echo "INFO" "Starting Git Conflict Finder Script..."

--- a/development-and-code-management/git/git-stash-manager.sh
+++ b/development-and-code-management/git/git-stash-manager.sh
@@ -91,14 +91,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Git Stash Manager Script"
   format-echo "INFO" "Starting Git Stash Manager Script..."

--- a/file-scripts/add-prefix-to-files.sh
+++ b/file-scripts/add-prefix-to-files.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Add Prefix to Files Script"
   format-echo "INFO" "Starting Add Prefix to Files Script..."

--- a/file-scripts/clean-old-files.sh
+++ b/file-scripts/clean-old-files.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Clean Old Files Script"
   format-echo "INFO" "Starting Clean Old Files Script..."

--- a/file-scripts/compare-files.sh
+++ b/file-scripts/compare-files.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Compare Files Script"
   format-echo "INFO" "Starting Compare Files Script..."

--- a/file-scripts/compress-tar-directory.sh
+++ b/file-scripts/compress-tar-directory.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Compress Directory Script"
   format-echo "INFO" "Starting Compress Directory Script..."

--- a/file-scripts/count-files.sh
+++ b/file-scripts/count-files.sh
@@ -95,14 +95,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Count Files Script"
   format-echo "INFO" "Starting Count Files Script..."

--- a/file-scripts/create-symlink.sh
+++ b/file-scripts/create-symlink.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Create Symbolic Link Script"
   format-echo "INFO" "Starting Create Symbolic Link Script..."

--- a/file-scripts/create-zip.sh
+++ b/file-scripts/create-zip.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Create Zip Archive Script"
   format-echo "INFO" "Starting Create Zip Archive Script..."

--- a/file-scripts/download-file.sh
+++ b/file-scripts/download-file.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Download File Script"
   format-echo "INFO" "Starting Download File Script..."

--- a/file-scripts/extract-tar.sh
+++ b/file-scripts/extract-tar.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Extract Tar Archive Script"
   format-echo "INFO" "Starting Extract Tar Archive Script..."

--- a/file-scripts/extract-zip.sh
+++ b/file-scripts/extract-zip.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Extract Zip Archive Script"
   format-echo "INFO" "Starting Extract Zip Archive Script..."

--- a/file-scripts/find-large-files.sh
+++ b/file-scripts/find-large-files.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Find Large Files Script"
   format-echo "INFO" "Starting Find Large Files Script..."

--- a/file-scripts/sync-directories.sh
+++ b/file-scripts/sync-directories.sh
@@ -100,14 +100,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Synchronize Directories Script"
   format-echo "INFO" "Starting Synchronize Directories Script..."

--- a/functions/print-functions/print-with-separator.sh
+++ b/functions/print-functions/print-with-separator.sh
@@ -1,3 +1,9 @@
+# Source common utilities so that helper functions are available wherever this
+# file is sourced.
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+COMMON_FUNCTION_FILE="$SCRIPT_DIR/../utility.sh"
+[ -f "$COMMON_FUNCTION_FILE" ] && source "$COMMON_FUNCTION_FILE"
+
 # Function to print a message with separators to both terminal and log file
 print_with_separator() {
   local MESSAGE="${1:-}"

--- a/functions/utility.sh
+++ b/functions/utility.sh
@@ -4,3 +4,15 @@
 command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
+
+# Configure logging by validating and creating the log file if needed
+# and redirecting all output through tee for real-time display.
+setup_log_file() {
+  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
+    if ! touch "$LOG_FILE" 2>/dev/null; then
+      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
+      exit 1
+    fi
+    exec > >(tee -a "$LOG_FILE") 2>&1
+  fi
+}

--- a/k8s-scripts/cluster-maintenance/clean-cluster.sh
+++ b/k8s-scripts/cluster-maintenance/clean-cluster.sh
@@ -725,14 +725,7 @@ main() {
 
   print_with_separator "Kubernetes Cluster Cleaning Script"
   
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
   
   format-echo "INFO" "Starting cluster cleaning process..."

--- a/k8s-scripts/cluster-maintenance/convert-cluster.sh
+++ b/k8s-scripts/cluster-maintenance/convert-cluster.sh
@@ -1260,14 +1260,7 @@ main() {
 
   print_with_separator "Kubernetes Cluster Conversion Script"
   
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
   
   format-echo "INFO" "Starting cluster conversion from $SOURCE_PROVIDER to $TARGET_PROVIDER..."

--- a/k8s-scripts/cluster-maintenance/rotate-certs.sh
+++ b/k8s-scripts/cluster-maintenance/rotate-certs.sh
@@ -936,14 +936,7 @@ main() {
 
   print_with_separator "Kubernetes Certificate Rotation Script"
   
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
   
   format-echo "INFO" "Starting certificate rotation process..."

--- a/k8s-scripts/cluster-management/cluster-configuration-management/apply-k8s-configuration.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/apply-k8s-configuration.sh
@@ -309,14 +309,7 @@ main() {
   # Parse arguments
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
 
   print_with_separator "Apply Kubernetes Configuration Script"

--- a/k8s-scripts/cluster-management/cluster-configuration-management/export-kubeconfig.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/export-kubeconfig.sh
@@ -464,14 +464,7 @@ main() {
   # Parse arguments
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
 
   print_with_separator "Kubernetes Kubeconfig Export Script"

--- a/k8s-scripts/cluster-management/cluster-configuration-management/merge-kubeconfig.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/merge-kubeconfig.sh
@@ -513,14 +513,7 @@ main() {
   # Parse arguments
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
 
   print_with_separator "Kubernetes Kubeconfig Merge Script"

--- a/k8s-scripts/cluster-management/cluster-state-management/create-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/create-cluster-local.sh
@@ -482,14 +482,7 @@ main() {
   # Parse command line arguments
   parse_args "$@"
   
-  # Configure log file if specified
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
   
   print_with_separator "Kubernetes Cluster Creation"

--- a/k8s-scripts/cluster-management/cluster-state-management/delete-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/delete-cluster-local.sh
@@ -275,14 +275,7 @@ main() {
   # Parse arguments
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
 
   print_with_separator "Kubernetes Cluster Deletion Script"

--- a/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
@@ -890,14 +890,7 @@ main() {
   # Parse arguments
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
 
   print_with_separator "Kubernetes Cluster Pause Script"

--- a/k8s-scripts/cluster-management/cluster-state-management/restart-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/restart-cluster-local.sh
@@ -430,14 +430,7 @@ main() {
   # Parse arguments
   parse_args "$@"
   
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
   
   print_with_separator "Kubernetes Cluster Restart"

--- a/k8s-scripts/cluster-management/cluster-state-management/resume-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/resume-cluster-local.sh
@@ -658,14 +658,7 @@ main() {
   #---------------------------------------------------------------------
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
   
   print_with_separator "Kubernetes Cluster Resume Script"

--- a/k8s-scripts/cluster-management/list-clusters.sh
+++ b/k8s-scripts/cluster-management/list-clusters.sh
@@ -816,14 +816,7 @@ main() {
   #---------------------------------------------------------------------
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
 
   print_with_separator "Kubernetes Clusters List Script"

--- a/k8s-scripts/cluster-management/scale-cluster-local.sh
+++ b/k8s-scripts/cluster-management/scale-cluster-local.sh
@@ -625,14 +625,7 @@ main() {
   #---------------------------------------------------------------------
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
 
   print_with_separator "Kubernetes Cluster Scaling Script"

--- a/k8s-scripts/cluster-management/switch-context.sh
+++ b/k8s-scripts/cluster-management/switch-context.sh
@@ -393,14 +393,7 @@ main() {
   #---------------------------------------------------------------------
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
   
   print_with_separator "Kubernetes Context Switcher Script"

--- a/k8s-scripts/cluster-management/upgrade-cluster-local.sh
+++ b/k8s-scripts/cluster-management/upgrade-cluster-local.sh
@@ -785,14 +785,7 @@ main() {
   #---------------------------------------------------------------------
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Kubernetes Cluster Upgrade Script"
   

--- a/k8s-scripts/image-management/build-and-load-images.sh
+++ b/k8s-scripts/image-management/build-and-load-images.sh
@@ -327,14 +327,7 @@ main() {
   #---------------------------------------------------------------------
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
-  # Configure log file if specified
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
 
   print_with_separator "Build and Load Images Script"

--- a/k8s-scripts/image-management/k8s-registry-pipeline.sh
+++ b/k8s-scripts/image-management/k8s-registry-pipeline.sh
@@ -363,14 +363,7 @@ main() {
   #---------------------------------------------------------------------
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
-  # Configure log file if specified
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
 
   print_with_separator "Docker Registry Setup and Image Push Script"

--- a/k8s-scripts/node-management/drain-nodes.sh
+++ b/k8s-scripts/node-management/drain-nodes.sh
@@ -540,14 +540,7 @@ main() {
   # Parse arguments
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Redirect stdout/stderr to log file and console
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
   
   print_with_separator "Kubernetes Node Drain Script"

--- a/k8s-scripts/node-management/label-nodes.sh
+++ b/k8s-scripts/node-management/label-nodes.sh
@@ -788,14 +788,7 @@ main() {
   #---------------------------------------------------------------------
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
   
   print_with_separator "Kubernetes Node Label Management Script"
   

--- a/k8s-scripts/node-management/taint-nodes.sh
+++ b/k8s-scripts/node-management/taint-nodes.sh
@@ -686,14 +686,7 @@ main() {
   #---------------------------------------------------------------------
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Kubernetes Node Taint Management Script"
   

--- a/k8s-scripts/pipelines/create-cluster-build-load-apply.sh
+++ b/k8s-scripts/pipelines/create-cluster-build-load-apply.sh
@@ -263,14 +263,7 @@ main() {
   #---------------------------------------------------------------------
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Create Cluster, Build/Load Images, and Apply Manifests Script"
   format-echo "INFO" "Starting Create Cluster, Build/Load Images, and Apply Manifests Script..."

--- a/k8s-scripts/workload-management/scale-workloads.sh
+++ b/k8s-scripts/workload-management/scale-workloads.sh
@@ -1102,14 +1102,7 @@ main() {
   # Parse arguments
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
   
   print_with_separator "Kubernetes Workload Scaling Script"
   

--- a/network-and-connectivity/active-host-scanner.sh
+++ b/network-and-connectivity/active-host-scanner.sh
@@ -125,14 +125,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Active Host Scanner Script"
   format-echo "INFO" "Starting Active Host Scanner Script..."

--- a/network-and-connectivity/arp-table-viewer.sh
+++ b/network-and-connectivity/arp-table-viewer.sh
@@ -126,14 +126,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "ARP Table Viewer Script"
   format-echo "INFO" "Starting ARP Table Viewer Script..."

--- a/network-and-connectivity/bandwidth-monitor.sh
+++ b/network-and-connectivity/bandwidth-monitor.sh
@@ -164,14 +164,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Bandwidth Monitor Script"
   format-echo "INFO" "Starting Bandwidth Monitor Script..."

--- a/network-and-connectivity/dns-resolver.sh
+++ b/network-and-connectivity/dns-resolver.sh
@@ -131,14 +131,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file - send all console output to log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    # Use tee to send all stdout to the log file
-    exec > >(tee -a "$LOG_FILE") 2>&1
+  setup_log_file
   fi
 
   print_with_separator "DNS Resolver Script"

--- a/network-and-connectivity/http-status-code-checker.sh
+++ b/network-and-connectivity/http-status-code-checker.sh
@@ -233,14 +233,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "HTTP Status Code Checker Script"
   format-echo "INFO" "Starting HTTP Status Code Checker Script..."

--- a/network-and-connectivity/ip-extractor-from-log-file.sh
+++ b/network-and-connectivity/ip-extractor-from-log-file.sh
@@ -229,14 +229,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "IP Extractor Script"
   format-echo "INFO" "Starting IP Extractor Script..."

--- a/network-and-connectivity/network-speed-test.sh
+++ b/network-and-connectivity/network-speed-test.sh
@@ -207,14 +207,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Network Speed Test Script"
   format-echo "INFO" "Starting Network Speed Test Script..."

--- a/network-and-connectivity/ping.sh
+++ b/network-and-connectivity/ping.sh
@@ -254,14 +254,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Ping Script"
   format-echo "INFO" "Starting Ping Script..."

--- a/network-and-connectivity/port-scanner.sh
+++ b/network-and-connectivity/port-scanner.sh
@@ -509,14 +509,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Port Scanner Script"
   format-echo "INFO" "Starting Port Scanner Script..."

--- a/security-and-access/firewall_configurator.sh
+++ b/security-and-access/firewall_configurator.sh
@@ -492,14 +492,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Firewall Configurator Script"
   format-echo "INFO" "Starting Firewall Configurator Script..."

--- a/security-and-access/group_access_auditor.sh
+++ b/security-and-access/group_access_auditor.sh
@@ -619,14 +619,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Group Access Auditor Script"
   format-echo "INFO" "Starting Group Access Auditor Script..."

--- a/security-and-access/malware_scanner.sh
+++ b/security-and-access/malware_scanner.sh
@@ -855,14 +855,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Malware Scanner Script"
   format-echo "INFO" "Starting Malware Scanner Script..."

--- a/security-and-access/password_generator.sh
+++ b/security-and-access/password_generator.sh
@@ -784,14 +784,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
   
   # Configure output file
   if [ -n "$OUTPUT_FILE" ]; then

--- a/security-and-access/secure_file_permissions.sh
+++ b/security-and-access/secure_file_permissions.sh
@@ -423,14 +423,7 @@ main() {
   # Parse command-line arguments
   parse_args "$@"
   
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
   
   print_with_separator "Secure File Permissions Script"
   format-echo "INFO" "Starting Secure File Permissions Script..."

--- a/security-and-access/ssh_key_manager.sh
+++ b/security-and-access/ssh_key_manager.sh
@@ -948,14 +948,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
   
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
   
   print_with_separator "Advanced SSH Key Manager Script"
   format-echo "INFO" "Starting SSH Key Manager..."

--- a/security-and-access/unused_ssh_key_detector.sh
+++ b/security-and-access/unused_ssh_key_detector.sh
@@ -989,14 +989,7 @@ remove_key() {
 main() {
   parse_args "$@"
   
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
   
   print_with_separator "Unused SSH Key Detector Script"
   format-echo "INFO" "Starting Unused SSH Key Detector Script..."

--- a/security-and-access/user_access_auditor.sh
+++ b/security-and-access/user_access_auditor.sh
@@ -903,14 +903,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
   
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
   
   print_with_separator "User Access Auditor Script"
   format-echo "INFO" "Starting User Access Auditor Script..."

--- a/system-scripts/check-process.sh
+++ b/system-scripts/check-process.sh
@@ -94,14 +94,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Check Process Script"
   format-echo "INFO" "Starting Check Process Script..."

--- a/system-scripts/check-updates.sh
+++ b/system-scripts/check-updates.sh
@@ -208,14 +208,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Check Updates Script"
   format-echo "INFO" "Starting Check Updates Script..."

--- a/system-scripts/cpu-monitor.sh
+++ b/system-scripts/cpu-monitor.sh
@@ -217,14 +217,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "CPU Monitor Script"
   format-echo "INFO" "Starting CPU Monitor Script..."

--- a/system-scripts/disk-usage.sh
+++ b/system-scripts/disk-usage.sh
@@ -208,14 +208,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Disk Usage Monitor Script"
   format-echo "INFO" "Starting Disk Usage Monitor Script..."

--- a/system-scripts/monitor-network.sh
+++ b/system-scripts/monitor-network.sh
@@ -439,14 +439,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Network Monitor Script"
   format-echo "INFO" "Starting Network Monitor Script..."

--- a/system-scripts/monitor-resources.sh
+++ b/system-scripts/monitor-resources.sh
@@ -515,14 +515,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Resource Monitor Script"
   format-echo "INFO" "Starting Resource Monitor Script..."

--- a/system-scripts/schedule-task.sh
+++ b/system-scripts/schedule-task.sh
@@ -374,14 +374,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Schedule Task Script"
   format-echo "INFO" "Starting Schedule Task Script..."

--- a/system-scripts/system-report.sh
+++ b/system-scripts/system-report.sh
@@ -725,14 +725,7 @@ main() {
   #---------------------------------------------------------------------
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "System Report Script"
   format-echo "INFO" "Starting System Report Script..."

--- a/utils/docker-utils/docker-cleanup.sh
+++ b/utils/docker-utils/docker-cleanup.sh
@@ -149,14 +149,7 @@ docker_cleanup() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Docker Cleanup Script"
   format-echo "INFO" "Starting Docker Cleanup Script..."

--- a/utils/docker-utils/docker-info.sh
+++ b/utils/docker-utils/docker-info.sh
@@ -118,14 +118,7 @@ show_docker_info() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Docker Info Script"
   format-echo "INFO" "Starting Docker Info Script..."

--- a/utils/docker-utils/inspect-resource-docker.sh
+++ b/utils/docker-utils/inspect-resource-docker.sh
@@ -123,14 +123,7 @@ inspect_resource() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Docker Resource Inspection Script"
   format-echo "INFO" "Starting Docker Resource Inspection Script..."

--- a/utils/docker-utils/real_time_container_logs.sh
+++ b/utils/docker-utils/real_time_container_logs.sh
@@ -81,14 +81,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Real-Time Docker Logs Script"
   format-echo "INFO" "Starting Real-Time Docker Logs Script..."

--- a/utils/docker-utils/start-docker-compose-in-tmux.sh
+++ b/utils/docker-utils/start-docker-compose-in-tmux.sh
@@ -85,14 +85,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Start Docker Compose in Tmux Script"
   format-echo "INFO" "Starting Docker Compose in tmux session: $SESSION_NAME"

--- a/utils/docker-utils/start-docker-containers.sh
+++ b/utils/docker-utils/start-docker-containers.sh
@@ -76,14 +76,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Start Docker Containers Script"
   format-echo "INFO" "Starting Start Docker Containers Script..."

--- a/utils/docker-utils/stop_all_containers.sh
+++ b/utils/docker-utils/stop_all_containers.sh
@@ -74,14 +74,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Stop All Docker Containers Script"
   format-echo "INFO" "Starting Stop All Docker Containers Script..."

--- a/utils/docker-utils/view-container_logs.sh
+++ b/utils/docker-utils/view-container_logs.sh
@@ -107,14 +107,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "View Docker Container Logs Script"
   format-echo "INFO" "Starting View Docker Container Logs Script..."

--- a/utils/generate-ssh-key.sh
+++ b/utils/generate-ssh-key.sh
@@ -85,14 +85,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "Generate SSH Key Script"
   format-echo "INFO" "Starting Generate SSH Key Script..."

--- a/utils/npm/npm-clean-cache.sh
+++ b/utils/npm/npm-clean-cache.sh
@@ -74,14 +74,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "NPM Clean Cache Script"
   format-echo "INFO" "Starting NPM Clean Cache Script..."

--- a/utils/npm/npm-list-global.sh
+++ b/utils/npm/npm-list-global.sh
@@ -74,14 +74,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "NPM List Global Packages Script"
   format-echo "INFO" "Starting NPM List Global Packages Script..."

--- a/utils/npm/npm-update-all.sh
+++ b/utils/npm/npm-update-all.sh
@@ -74,14 +74,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "NPM Update All Packages Script"
   format-echo "INFO" "Starting NPM Update All Packages Script..."

--- a/utils/services-utils/backup-postgresql-compressed.sh
+++ b/utils/services-utils/backup-postgresql-compressed.sh
@@ -93,14 +93,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "PostgreSQL Backup Script"
   format-echo "INFO" "Starting PostgreSQL Backup Script..."

--- a/utils/services-utils/backup-postgresql.sh
+++ b/utils/services-utils/backup-postgresql.sh
@@ -93,14 +93,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "PostgreSQL Backup Script"
   format-echo "INFO" "Starting PostgreSQL Backup Script..."

--- a/utils/services-utils/restore-postgresql-compressed.sh
+++ b/utils/services-utils/restore-postgresql-compressed.sh
@@ -93,14 +93,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "PostgreSQL Restore Script"
   format-echo "INFO" "Starting PostgreSQL Restore Script..."

--- a/utils/services-utils/restore-postgresql.sh
+++ b/utils/services-utils/restore-postgresql.sh
@@ -93,14 +93,7 @@ parse_args() {
 main() {
   parse_args "$@"
 
-  # Configure log file
-  if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-      echo -e "\033[1;31mError:\033[0m Cannot write to log file $LOG_FILE."
-      exit 1
-    fi
-    exec > >(tee -a "$LOG_FILE") 2>&1
-  fi
+  setup_log_file
 
   print_with_separator "PostgreSQL Restore Script"
   format-echo "INFO" "Starting PostgreSQL Restore Script..."


### PR DESCRIPTION
## Summary
- add `setup_log_file` helper in `functions/utility.sh`
- auto-source `utility.sh` from `print-with-separator.sh`
- replace inline log setup with `setup_log_file` across scripts

## Testing
- `./utils/run-shellcheck.sh` *(fails: shellcheck is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68825e804e20832587ac0ed5fdb7d45a