### PR TITLE
Fix $? checks in various scripts

### DIFF
--- a/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
@@ -429,9 +429,7 @@ drain_cluster_nodes() {
     kubectl cordon "$node_name" --timeout="${WAIT_TIMEOUT}s" &>/dev/null
     
     format-echo "INFO" "Draining node $node_name"
-    kubectl drain "$node_name" --ignore-daemonsets --delete-emptydir-data --force --timeout="${WAIT_TIMEOUT}s" &>/dev/null
-    
-    if [[ $? -eq 0 ]]; then
+    if kubectl drain "$node_name" --ignore-daemonsets --delete-emptydir-data --force --timeout="${WAIT_TIMEOUT}s" &>/dev/null; then
       format-echo "SUCCESS" "Node $node_name drained successfully"
     else
       format-echo "WARNING" "Failed to drain node $node_name completely, continuing anyway"
@@ -481,8 +479,7 @@ create_cluster_snapshot() {
             vm_name="$cluster"
           fi
           
-          VBoxManage snapshot "$vm_name" take "$snapshot_name" &>/dev/null
-          if [[ $? -eq 0 ]]; then
+          if VBoxManage snapshot "$vm_name" take "$snapshot_name" &>/dev/null; then
             format-echo "SUCCESS" "Created VirtualBox snapshot: $snapshot_name"
             echo "SNAPSHOT_CREATED=true" >> "$STATE_DIR/${cluster}-${provider}.state"
             echo "SNAPSHOT_NAME=$snapshot_name" >> "$STATE_DIR/${cluster}-${provider}.state"
@@ -592,8 +589,7 @@ pause_cluster() {
       # First try the pause feature (for newer minikube versions)
       if minikube help | grep -q "pause"; then
         format-echo "INFO" "Using minikube pause feature"
-        minikube pause -p "$cluster"
-        if [[ $? -eq 0 ]]; then
+        if minikube pause -p "$cluster"; then
           format-echo "SUCCESS" "Minikube cluster '$cluster' paused successfully"
           return 0
         else
@@ -603,8 +599,7 @@ pause_cluster() {
       
       # Fall back to stopping the cluster
       format-echo "INFO" "Stopping minikube cluster '$cluster'"
-      minikube stop -p "$cluster"
-      if [[ $? -eq 0 ]]; then
+      if minikube stop -p "$cluster"; then
         format-echo "SUCCESS" "Minikube cluster '$cluster' stopped successfully"
         return 0
       else
@@ -632,9 +627,7 @@ pause_cluster() {
         container_name=$(docker inspect --format "{{.Name}}" "$container_id" | sed 's|^/||')
         
         format-echo "INFO" "Stopping container: $container_name"
-        docker stop "$container_id" > /dev/null
-        
-        if [[ $? -eq 0 ]]; then
+        if docker stop "$container_id" > /dev/null; then
           format-echo "SUCCESS" "Container $container_name stopped successfully"
         else
           format-echo "ERROR" "Failed to stop container $container_name"
@@ -649,9 +642,7 @@ pause_cluster() {
     k3d)
       # k3d has a stop feature
       format-echo "INFO" "Stopping k3d cluster '$cluster'"
-      k3d cluster stop "$cluster"
-      
-      if [[ $? -eq 0 ]]; then
+      if k3d cluster stop "$cluster"; then
         format-echo "SUCCESS" "K3d cluster '$cluster' stopped successfully"
         return 0
       else

--- a/security-and-access/unused_ssh_key_detector.sh
+++ b/security-and-access/unused_ssh_key_detector.sh
@@ -410,9 +410,9 @@ is_in_ssh_agent() {
   fi
   
   # Check if the key is loaded in SSH agent
-  local agent_keys=$(ssh-add -l 2>/dev/null)
-  if [[ $? -eq 0 && -n "$agent_keys" ]]; then
-    if echo "$agent_keys" | grep -q "$key_fingerprint"; then
+  local agent_keys
+  if agent_keys=$(ssh-add -l 2>/dev/null); then
+    if [[ -n "$agent_keys" ]] && echo "$agent_keys" | grep -q "$key_fingerprint"; then
       return 0  # Key is loaded in SSH agent
     fi
   fi

--- a/system-scripts/monitor-resources.sh
+++ b/system-scripts/monitor-resources.sh
@@ -351,9 +351,8 @@ monitor_resources() {
   if [ -n "$CONTAINER" ]; then
     # Monitoring Docker container
     local container_stats
-    container_stats=$(get_container_stats "$CONTAINER")
-    
-    if [ $? -eq 0 ]; then
+
+    if container_stats=$(get_container_stats "$CONTAINER"); then
       # Parse container stats
       cpu_usage=$(echo "$container_stats" | cut -d':' -f1)
       memory_usage=$(echo "$container_stats" | cut -d':' -f2)

--- a/utils/docker-utils/start-docker-compose-in-tmux.sh
+++ b/utils/docker-utils/start-docker-compose-in-tmux.sh
@@ -116,9 +116,7 @@ main() {
 
   # Create a new tmux session and start Docker Compose
   format-echo "INFO" "Creating a new tmux session and starting Docker Compose..."
-  tmux new-session -d -s "$SESSION_NAME" -c "$DOCKER_COMPOSE_DIR" "docker-compose up"
-
-  if [ $? -eq 0 ]; then
+  if tmux new-session -d -s "$SESSION_NAME" -c "$DOCKER_COMPOSE_DIR" "docker-compose up"; then
     format-echo "SUCCESS" "Docker Compose started in tmux session '$SESSION_NAME'."
   else
     format-echo "ERROR" "Failed to start Docker Compose in tmux session."

--- a/utils/docker-utils/stop_all_containers.sh
+++ b/utils/docker-utils/stop_all_containers.sh
@@ -96,8 +96,7 @@ main() {
 
   # Stop all running containers
   format-echo "INFO" "Stopping all running containers..."
-  STOPPED_CONTAINERS=$(docker stop $RUNNING_CONTAINERS)
-  if [ $? -eq 0 ]; then
+  if STOPPED_CONTAINERS=$(docker stop $RUNNING_CONTAINERS); then
     format-echo "SUCCESS" "Stopped containers: $STOPPED_CONTAINERS"
   else
     format-echo "ERROR" "Failed to stop some containers."


### PR DESCRIPTION
## Summary
- refactor start-docker-compose-in-tmux to check command status inline
- stop_all_containers uses inline docker stop check
- monitor-resources inlines get_container_stats check
- pause-cluster-local cleans up $? checks
- unused_ssh_key_detector captures ssh-agent output safely

## Testing
- `./utils/run-shellcheck.sh` *(fails: shellcheck is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688263bf4e448325a8e04a545ade3cb1