### PR TITLE
Refactor malware scanner find

### DIFF
--- a/security-and-access/malware_scanner.sh
+++ b/security-and-access/malware_scanner.sh
@@ -243,38 +243,32 @@ initialize_scan_results() {
 # Get the total file count for progress reporting
 get_file_count() {
   local dir="$1"
-  local depth_arg=""
-  
+
+  # Build find arguments dynamically to avoid eval
+  local find_args=("$dir")
   if [ "$SCAN_DEPTH" -ge 0 ]; then
-    depth_arg="-maxdepth $SCAN_DEPTH"
+    find_args+=("-maxdepth" "$SCAN_DEPTH")
   fi
-  
-  # Handle hidden files according to settings
-  local hidden_arg=""
+
   if [ "$CHECK_HIDDEN" != true ]; then
-    hidden_arg="-not -path '*/\.*'"
+    find_args+=("-not" "-path" "*/.*")
   fi
-  
-  # Count files
-  # Using eval to properly handle the conditional arguments
-  eval find \"$dir\" $depth_arg -type f $hidden_arg | wc -l
+
+  find "${find_args[@]}" -type f | wc -l
 }
 
 # Main scanning function
 scan_directory() {
   local dir="$1"
   local total_files
-  local depth_arg=""
-  
-  # Set depth argument if specified
+  # Build find arguments dynamically to avoid eval
+  local find_args=("$dir")
   if [ "$SCAN_DEPTH" -ge 0 ]; then
-    depth_arg="-maxdepth $SCAN_DEPTH"
+    find_args+=("-maxdepth" "$SCAN_DEPTH")
   fi
-  
-  # Handle hidden files according to settings
-  local hidden_arg=""
+
   if [ "$CHECK_HIDDEN" != true ]; then
-    hidden_arg="-not -path '*/\.*'"
+    find_args+=("-not" "-path" "*/.*")
   fi
   
   # Get total file count for progress if needed
@@ -292,8 +286,7 @@ scan_directory() {
   file_list=$(mktemp)
   TEMP_FILES+=("$file_list")
   
-  # Using eval to properly handle the conditional arguments
-  eval find \"$dir\" $depth_arg -type f $hidden_arg > "$file_list"
+  find "${find_args[@]}" -type f > "$file_list"
   
   # Check if we found any files
   if [ ! -s "$file_list" ]; then


### PR DESCRIPTION
## Summary
- improve argument handling in `malware_scanner.sh`
- remove `eval` usage when building find commands

## Testing
- `bash security-and-access/malware_scanner.sh /tmp/test_scan --no-progress --no-summary`
- `bash security-and-access/malware_scanner.sh /tmp/test_scan --depth 1 --no-hidden --no-progress --no-summary`
- `./utils/run-shellcheck.sh` *(fails: shellcheck not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688376390f0c8325ac1950a906e94bf4