### PR TITLE
Update shellcheck workflow trigger

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,8 +1,7 @@
 name: Shellcheck
 
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   shellcheck:


### PR DESCRIPTION
## Summary
- only run shellcheck workflow when manually triggered

## Testing
- `./utils/run-shellcheck.sh` *(fails: shellcheck not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688377ecac788325b26ffa16e7ed8467