### PR TITLE
Update README to stress shellcheck requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ chmod +x shell-scripts.sh */*.sh */*/*.sh
 ```
 
 ### Lint scripts with shellcheck
-Run shellcheck on all scripts:
+`shellcheck` **must** be installed to run the lint script:
 ```bash
 ./utils/run-shellcheck.sh
 ```
-If `shellcheck` is not installed, install it via your package manager (for example, `sudo apt-get install shellcheck`).
+Install it via your package manager if needed:
+```bash
+sudo apt-get install shellcheck
+```
 Shellcheck is automatically run on pushes and pull requests via GitHub Actions.
 
 ### Running a script


### PR DESCRIPTION
## Summary
- clarify that `shellcheck` must be installed before running `./utils/run-shellcheck.sh`
- show an install command snippet in the README

## Testing
- `./utils/run-shellcheck.sh` *(fails: shellcheck not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68837d92b9548325b523b7bb9b15eb0c