### PR TITLE
Add strict mode to shell scripts

### DIFF
--- a/functions/format-echo/format-echo.sh
+++ b/functions/format-echo/format-echo.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Utility script to log messages with log levels, timestamps, and optional file logging.
 
 # Function to log messages with log levels and timestamps

--- a/shell-scripts.sh
+++ b/shell-scripts.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # shell-scripts.sh
 # A wrapper script to manage and execute all shell scripts in the same directory as this script
 

--- a/utils/docker-utils/wait-for-it.sh
+++ b/utils/docker-utils/wait-for-it.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Use this script to test if a given TCP host/port are available
 
 WAITFORIT_cmdname=${0##*/}


### PR DESCRIPTION
## Summary
- add `set -euo pipefail` right after the shebang for better error handling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68837d86a31c8325998c6b6620241ac0