### PR TITLE
Resolve shellcheck errors

### DIFF
--- a/functions/common-init.sh
+++ b/functions/common-init.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # common-init.sh
 # Determine repository root relative to the caller and source shared functions.
 

--- a/functions/format-echo/format-echo.sh
+++ b/functions/format-echo/format-echo.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 format-echo() {
   local LEVEL=$1
   local MESSAGE=$2
-  local TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S")
+  local TIMESTAMP
+  TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S")
   local LEVEL_COLOR=""
 
   # Set color based on log level
@@ -36,7 +37,8 @@ format-echo() {
   local FORMATTED_MESSAGE="$TIMESTAMP [${LEVEL_COLOR}${LEVEL}\033[0m] $MESSAGE"
 
   # Remove color codes for the log file
-  local PLAIN_MESSAGE=$(echo -e "$FORMATTED_MESSAGE" | sed 's/\x1b\[[0-9;]*m//g')
+  local PLAIN_MESSAGE
+  PLAIN_MESSAGE=$(echo -e "$FORMATTED_MESSAGE" | sed 's/\x1b\[[0-9;]*m//g')
 
   # Log to file and console using tee
   if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then

--- a/functions/print-functions/print-with-separator.sh
+++ b/functions/print-functions/print-with-separator.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Source common utilities so that helper functions are available wherever this
 # file is sourced.
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"

--- a/functions/utility.sh
+++ b/functions/utility.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared utility functions
 
 # Check if a command exists

--- a/k8s-scripts/cluster-maintenance/clean-cluster.sh
+++ b/k8s-scripts/cluster-maintenance/clean-cluster.sh
@@ -695,7 +695,6 @@ main() {
   print_with_separator "Kubernetes Cluster Cleaning Script"
   
   setup_log_file
-  fi
   
   format-echo "INFO" "Starting cluster cleaning process..."
   

--- a/k8s-scripts/cluster-maintenance/convert-cluster.sh
+++ b/k8s-scripts/cluster-maintenance/convert-cluster.sh
@@ -1230,7 +1230,6 @@ main() {
   print_with_separator "Kubernetes Cluster Conversion Script"
   
   setup_log_file
-  fi
   
   format-echo "INFO" "Starting cluster conversion from $SOURCE_PROVIDER to $TARGET_PROVIDER..."
   

--- a/k8s-scripts/cluster-maintenance/rotate-certs.sh
+++ b/k8s-scripts/cluster-maintenance/rotate-certs.sh
@@ -906,7 +906,6 @@ main() {
   print_with_separator "Kubernetes Certificate Rotation Script"
   
   setup_log_file
-  fi
   
   format-echo "INFO" "Starting certificate rotation process..."
   

--- a/k8s-scripts/cluster-management/cluster-configuration-management/apply-k8s-configuration.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/apply-k8s-configuration.sh
@@ -287,7 +287,6 @@ main() {
   parse_args "$@"
 
   setup_log_file
-  fi
 
   print_with_separator "Apply Kubernetes Configuration Script"
   

--- a/k8s-scripts/cluster-management/cluster-configuration-management/export-kubeconfig.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/export-kubeconfig.sh
@@ -434,7 +434,6 @@ main() {
   parse_args "$@"
 
   setup_log_file
-  fi
 
   print_with_separator "Kubernetes Kubeconfig Export Script"
   

--- a/k8s-scripts/cluster-management/cluster-configuration-management/merge-kubeconfig.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/merge-kubeconfig.sh
@@ -483,7 +483,6 @@ main() {
   parse_args "$@"
 
   setup_log_file
-  fi
 
   print_with_separator "Kubernetes Kubeconfig Merge Script"
   

--- a/k8s-scripts/cluster-management/cluster-state-management/create-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/create-cluster-local.sh
@@ -452,7 +452,6 @@ main() {
   parse_args "$@"
   
   setup_log_file
-  fi
   
   print_with_separator "Kubernetes Cluster Creation"
   

--- a/k8s-scripts/cluster-management/cluster-state-management/delete-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/delete-cluster-local.sh
@@ -245,7 +245,6 @@ main() {
   parse_args "$@"
 
   setup_log_file
-  fi
 
   print_with_separator "Kubernetes Cluster Deletion Script"
   

--- a/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
@@ -851,7 +851,6 @@ main() {
   parse_args "$@"
 
   setup_log_file
-  fi
 
   print_with_separator "Kubernetes Cluster Pause Script"
   

--- a/k8s-scripts/cluster-management/cluster-state-management/restart-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/restart-cluster-local.sh
@@ -400,7 +400,6 @@ main() {
   parse_args "$@"
   
   setup_log_file
-  fi
   
   print_with_separator "Kubernetes Cluster Restart"
 

--- a/k8s-scripts/cluster-management/cluster-state-management/resume-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/resume-cluster-local.sh
@@ -628,7 +628,6 @@ main() {
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
   setup_log_file
-  fi
   
   print_with_separator "Kubernetes Cluster Resume Script"
 

--- a/k8s-scripts/cluster-management/list-clusters.sh
+++ b/k8s-scripts/cluster-management/list-clusters.sh
@@ -786,7 +786,6 @@ main() {
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
   setup_log_file
-  fi
 
   print_with_separator "Kubernetes Clusters List Script"
   

--- a/k8s-scripts/cluster-management/scale-cluster-local.sh
+++ b/k8s-scripts/cluster-management/scale-cluster-local.sh
@@ -595,7 +595,6 @@ main() {
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
   setup_log_file
-  fi
 
   print_with_separator "Kubernetes Cluster Scaling Script"
   

--- a/k8s-scripts/cluster-management/switch-context.sh
+++ b/k8s-scripts/cluster-management/switch-context.sh
@@ -363,7 +363,6 @@ main() {
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
   setup_log_file
-  fi
   
   print_with_separator "Kubernetes Context Switcher Script"
 

--- a/k8s-scripts/image-management/build-and-load-images.sh
+++ b/k8s-scripts/image-management/build-and-load-images.sh
@@ -305,7 +305,6 @@ main() {
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
   setup_log_file
-  fi
 
   print_with_separator "Build and Load Images Script"
   

--- a/k8s-scripts/image-management/k8s-registry-pipeline.sh
+++ b/k8s-scripts/image-management/k8s-registry-pipeline.sh
@@ -333,7 +333,6 @@ main() {
   # LOG CONFIGURATION
   #---------------------------------------------------------------------
   setup_log_file
-  fi
 
   print_with_separator "Docker Registry Setup and Image Push Script"
   

--- a/k8s-scripts/node-management/drain-nodes.sh
+++ b/k8s-scripts/node-management/drain-nodes.sh
@@ -510,7 +510,6 @@ main() {
   parse_args "$@"
 
   setup_log_file
-  fi
   
   print_with_separator "Kubernetes Node Drain Script"
   

--- a/network-and-connectivity/dns-resolver.sh
+++ b/network-and-connectivity/dns-resolver.sh
@@ -114,7 +114,6 @@ main() {
   parse_args "$@"
 
   setup_log_file
-  fi
 
   print_with_separator "DNS Resolver Script"
   format-echo "INFO" "Starting DNS Resolver Script..."

--- a/network-and-connectivity/ip-extractor-from-log-file.sh
+++ b/network-and-connectivity/ip-extractor-from-log-file.sh
@@ -179,13 +179,15 @@ extract_ips() {
   
   # Extract IPv4 addresses
   ipv4_list=$(extract_ipv4 "$INPUT_LOG")
-  local ipv4_count=$(echo "$ipv4_list" | grep -v '^$' | wc -l | tr -d ' ')
+  local ipv4_count
+  ipv4_count=$(echo "$ipv4_list" | grep -vc '^$')
   extracted_count=$ipv4_count
   
   # Extract IPv6 addresses if requested
   if [[ "$INCLUDE_IPV6" == true ]]; then
     ipv6_list=$(extract_ipv6 "$INPUT_LOG")
-    local ipv6_count=$(echo "$ipv6_list" | grep -v '^$' | wc -l | tr -d ' ')
+    local ipv6_count
+    ipv6_count=$(echo "$ipv6_list" | grep -vc '^$')
     extracted_count=$((extracted_count + ipv6_count))
   fi
   

--- a/utils/docker-utils/wait-for-it.sh
+++ b/utils/docker-utils/wait-for-it.sh
@@ -151,7 +151,7 @@ if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
     WAITFORIT_ISBUSY=1
     # Check if busybox timeout uses -t flag
     # (recent Alpine versions don't support -t anymore)
-    if timeout &>/dev/stdout | grep -q -e '-t '; then
+    if timeout 2>&1 | grep -q -e '-t '; then
         WAITFORIT_BUSYTIMEFLAG="-t"
     fi
 else


### PR DESCRIPTION
## Summary
- annotate utility scripts for shellcheck
- handle `TIMESTAMP` and `PLAIN_MESSAGE` assignments separately
- count IPs in a more idiomatic way
- fix stray `fi` after `setup_log_file`
- avoid redirect override in `wait-for-it.sh`

## Testing
- `./utils/run-shellcheck.sh`


------
https://chatgpt.com/codex/tasks/task_e_68837f26f57c8325a42ee934cb07c008