### PR TITLE
Fix shellcheck warnings in docker utilities

### DIFF
--- a/utils/docker-utils/docker-cleanup.sh
+++ b/utils/docker-utils/docker-cleanup.sh
@@ -7,9 +7,12 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================
+# LOG file path used by utility functions
+# shellcheck disable=SC2034
 LOG_FILE="/dev/null"
 
 usage() {
@@ -69,7 +72,7 @@ docker_cleanup() {
   fi
 
   # Confirm before proceeding
-  read -p "This will delete ALL Docker containers, images, volumes, and networks. Are you sure? (y/N): " confirm
+  read -r -p "This will delete ALL Docker containers, images, volumes, and networks. Are you sure? (y/N): " confirm
   if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
     format-echo "INFO" "Cleanup canceled."
     print_with_separator "End of Docker Cleanup Script"
@@ -80,7 +83,7 @@ docker_cleanup() {
   RUNNING_CONTAINERS=$(docker ps -q)
   if [ -n "$RUNNING_CONTAINERS" ]; then
     format-echo "INFO" "Stopping all running containers..."
-    docker stop $RUNNING_CONTAINERS
+    docker stop "$RUNNING_CONTAINERS"
   else
     format-echo "INFO" "No running containers to stop."
   fi
@@ -89,7 +92,7 @@ docker_cleanup() {
   ALL_CONTAINERS=$(docker ps -aq)
   if [ -n "$ALL_CONTAINERS" ]; then
     format-echo "INFO" "Removing all containers..."
-    docker rm $ALL_CONTAINERS
+    docker rm "$ALL_CONTAINERS"
   else
     format-echo "INFO" "No containers to remove."
   fi
@@ -98,7 +101,7 @@ docker_cleanup() {
   ALL_IMAGES=$(docker images -q)
   if [ -n "$ALL_IMAGES" ]; then
     format-echo "INFO" "Removing all images..."
-    docker rmi $ALL_IMAGES -f
+    docker rmi "$ALL_IMAGES" -f
   else
     format-echo "INFO" "No images to remove."
   fi
@@ -107,7 +110,7 @@ docker_cleanup() {
   ALL_VOLUMES=$(docker volume ls -q)
   if [ -n "$ALL_VOLUMES" ]; then
     format-echo "INFO" "Removing all volumes..."
-    docker volume rm $ALL_VOLUMES
+    docker volume rm "$ALL_VOLUMES"
   else
     format-echo "INFO" "No volumes to remove."
   fi
@@ -116,7 +119,7 @@ docker_cleanup() {
   ALL_NETWORKS=$(docker network ls -q)
   if [ -n "$ALL_NETWORKS" ]; then
     format-echo "INFO" "Removing all networks..."
-    docker network rm $ALL_NETWORKS
+    docker network rm "$ALL_NETWORKS"
   else
     format-echo "INFO" "No networks to remove."
   fi

--- a/utils/docker-utils/docker-info.sh
+++ b/utils/docker-utils/docker-info.sh
@@ -7,9 +7,12 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================
+# LOG file path used by utility functions
+# shellcheck disable=SC2034
 LOG_FILE="/dev/null"
 
 usage() {

--- a/utils/docker-utils/start-docker-compose-in-tmux.sh
+++ b/utils/docker-utils/start-docker-compose-in-tmux.sh
@@ -7,11 +7,14 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================
 DOCKER_COMPOSE_DIR=""
 SESSION_NAME=""
+# LOG file path used by utility functions
+# shellcheck disable=SC2034
 LOG_FILE="/dev/null"
 
 usage() {
@@ -102,7 +105,7 @@ main() {
   # Check if the tmux session already exists
   if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
     format-echo "INFO" "Tmux session '$SESSION_NAME' already exists."
-    read -p "Do you want to attach to the existing session? (y/n) " ATTACH_EXISTING
+    read -r -p "Do you want to attach to the existing session? (y/n) " ATTACH_EXISTING
     if [ "$ATTACH_EXISTING" = "y" ]; then
       tmux attach-session -t "$SESSION_NAME"
       print_with_separator "End of Start Docker Compose in Tmux Script"
@@ -125,7 +128,7 @@ main() {
   fi
 
   # Optionally, attach to the tmux session
-  read -p "Do you want to attach to the tmux session? (y/n) " ATTACH
+  read -r -p "Do you want to attach to the tmux session? (y/n) " ATTACH
   if [ "$ATTACH" = "y" ]; then
     tmux attach-session -t "$SESSION_NAME"
   fi

--- a/utils/docker-utils/start-docker-containers.sh
+++ b/utils/docker-utils/start-docker-containers.sh
@@ -7,9 +7,12 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================
+# LOG file path used by utility functions
+# shellcheck disable=SC2034
 LOG_FILE="/dev/null"
 CONTAINERS=()
 

--- a/utils/docker-utils/stop_all_containers.sh
+++ b/utils/docker-utils/stop_all_containers.sh
@@ -7,9 +7,12 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================
+# LOG file path used by utility functions
+# shellcheck disable=SC2034
 LOG_FILE="/dev/null"
 
 usage() {
@@ -87,7 +90,7 @@ main() {
   # Display confirmation prompt
   format-echo "INFO" "The following containers will be stopped:"
   docker ps --format "table {{.ID}}\t{{.Names}}"
-  read -p "Are you sure you want to stop all running containers? (y/N): " CONFIRM
+  read -r -p "Are you sure you want to stop all running containers? (y/N): " CONFIRM
   if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
     format-echo "INFO" "Operation canceled."
     print_with_separator "End of Stop All Docker Containers Script"
@@ -96,7 +99,7 @@ main() {
 
   # Stop all running containers
   format-echo "INFO" "Stopping all running containers..."
-  if STOPPED_CONTAINERS=$(docker stop $RUNNING_CONTAINERS); then
+  if STOPPED_CONTAINERS=$(docker stop "$RUNNING_CONTAINERS"); then
     format-echo "SUCCESS" "Stopped containers: $STOPPED_CONTAINERS"
   else
     format-echo "ERROR" "Failed to stop some containers."

--- a/utils/docker-utils/view-container_logs.sh
+++ b/utils/docker-utils/view-container_logs.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================
@@ -14,6 +15,8 @@ CONTAINER_NAME=""
 FOLLOW=""
 SINCE=""
 UNTIL=""
+# LOG file path used by utility functions
+# shellcheck disable=SC2034
 LOG_FILE="/dev/null"
 
 usage() {
@@ -117,7 +120,7 @@ main() {
 
   format-echo "INFO" "Viewing logs for container: $CONTAINER_NAME"
   format-echo "INFO" "Executing: docker logs $FOLLOW $SINCE $UNTIL $CONTAINER_NAME"
-  docker logs $FOLLOW $SINCE $UNTIL "$CONTAINER_NAME"
+  docker logs "$FOLLOW" "$SINCE" "$UNTIL" "$CONTAINER_NAME"
 
   print_with_separator "End of View Docker Container Logs Script"
   if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "/dev/null" ]; then

--- a/utils/docker-utils/wait-for-it.sh
+++ b/utils/docker-utils/wait-for-it.sh
@@ -47,7 +47,7 @@ wait_for()
         fi
         sleep 1
     done
-    return $WAITFORIT_result
+    return "$WAITFORIT_result"
 }
 
 wait_for_wrapper()
@@ -59,7 +59,7 @@ wait_for_wrapper()
         timeout $WAITFORIT_BUSYTIMEFLAG "$WAITFORIT_TIMEOUT" "$0" --child --host="$WAITFORIT_HOST" --port="$WAITFORIT_PORT" --timeout="$WAITFORIT_TIMEOUT" &
     fi
     WAITFORIT_PID=$!
-    trap "kill -INT -$WAITFORIT_PID" INT
+    trap 'kill -INT -$WAITFORIT_PID' INT
     wait $WAITFORIT_PID
     WAITFORIT_RESULT=$?
     if [[ $WAITFORIT_RESULT -ne 0 ]]; then
@@ -73,7 +73,7 @@ while [[ $# -gt 0 ]]
 do
     case "$1" in
         *:* )
-        WAITFORIT_hostport=(${1//:/ })
+        IFS=':' read -r -a WAITFORIT_hostport <<< "$1"
         WAITFORIT_HOST=${WAITFORIT_hostport[0]}
         WAITFORIT_PORT=${WAITFORIT_hostport[1]}
         shift 1
@@ -172,7 +172,7 @@ else
     fi
 fi
 
-if [[ $WAITFORIT_CLI != "" ]]; then
+if [[ ${#WAITFORIT_CLI[@]} -ne 0 ]]; then
     if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
         echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
         exit $WAITFORIT_RESULT

--- a/utils/run-shellcheck.sh
+++ b/utils/run-shellcheck.sh
@@ -21,4 +21,4 @@ if ! command_exists shellcheck; then
   exit 1
 fi
 
-find "$REPO_ROOT" -type f -name '*.sh' -exec shellcheck "$@" {} +
+find "$REPO_ROOT" -type f -name '*.sh' -exec shellcheck -x "$@" {} +


### PR DESCRIPTION
## Summary
- run shellcheck with `-x` by default
- fix quoting and read flags in `wait-for-it.sh`
- document sourced files for shellcheck
- suppress false positives for LOG_FILE
- quote variables in docker cleanup script

## Testing
- `shellcheck -x utils/docker-utils/start-docker-containers.sh`
- `shellcheck -x utils/docker-utils/docker-info.sh`
- `shellcheck -x utils/docker-utils/docker-cleanup.sh`
- `shellcheck -x utils/docker-utils/stop_all_containers.sh`
- `shellcheck -x utils/docker-utils/start-docker-compose-in-tmux.sh`
- `shellcheck -x utils/docker-utils/view-container_logs.sh`
- `shellcheck -x utils/docker-utils/wait-for-it.sh`
- `./utils/run-shellcheck.sh >/tmp/shellcheck.log`

------
https://chatgpt.com/codex/tasks/task_e_68838a12ec148325b099aff206243dde