### PR TITLE
Add shellcheck annotations for common init

### DIFF
--- a/development-and-code-management/dependencies-updater/dependency-updater-npm.sh
+++ b/development-and-code-management/dependencies-updater/dependency-updater-npm.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/development-and-code-management/dependencies-updater/dependency-updater-python.sh
+++ b/development-and-code-management/dependencies-updater/dependency-updater-python.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/add-prefix-to-files.sh
+++ b/file-scripts/add-prefix-to-files.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/clean-old-files.sh
+++ b/file-scripts/clean-old-files.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/compare-files.sh
+++ b/file-scripts/compare-files.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/compress-tar-directory.sh
+++ b/file-scripts/compress-tar-directory.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/count-files.sh
+++ b/file-scripts/count-files.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/create-symlink.sh
+++ b/file-scripts/create-symlink.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/create-zip.sh
+++ b/file-scripts/create-zip.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/download-file.sh
+++ b/file-scripts/download-file.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/extract-tar.sh
+++ b/file-scripts/extract-tar.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/extract-zip.sh
+++ b/file-scripts/extract-zip.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/find-large-files.sh
+++ b/file-scripts/find-large-files.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/file-scripts/sync-directories.sh
+++ b/file-scripts/sync-directories.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-maintenance/clean-cluster.sh
+++ b/k8s-scripts/cluster-maintenance/clean-cluster.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-maintenance/convert-cluster.sh
+++ b/k8s-scripts/cluster-maintenance/convert-cluster.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-maintenance/rotate-certs.sh
+++ b/k8s-scripts/cluster-maintenance/rotate-certs.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-configuration-management/apply-k8s-configuration.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/apply-k8s-configuration.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-configuration-management/export-kubeconfig.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/export-kubeconfig.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-configuration-management/merge-kubeconfig.sh
+++ b/k8s-scripts/cluster-management/cluster-configuration-management/merge-kubeconfig.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-state-management/create-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/create-cluster-local.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-state-management/delete-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/delete-cluster-local.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/pause-cluster-local.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-state-management/restart-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/restart-cluster-local.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/cluster-state-management/resume-cluster-local.sh
+++ b/k8s-scripts/cluster-management/cluster-state-management/resume-cluster-local.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/list-clusters.sh
+++ b/k8s-scripts/cluster-management/list-clusters.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/scale-cluster-local.sh
+++ b/k8s-scripts/cluster-management/scale-cluster-local.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/switch-context.sh
+++ b/k8s-scripts/cluster-management/switch-context.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/cluster-management/upgrade-cluster-local.sh
+++ b/k8s-scripts/cluster-management/upgrade-cluster-local.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/image-management/build-and-load-images.sh
+++ b/k8s-scripts/image-management/build-and-load-images.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/image-management/k8s-registry-pipeline.sh
+++ b/k8s-scripts/image-management/k8s-registry-pipeline.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/node-management/drain-nodes.sh
+++ b/k8s-scripts/node-management/drain-nodes.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/node-management/label-nodes.sh
+++ b/k8s-scripts/node-management/label-nodes.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/node-management/taint-nodes.sh
+++ b/k8s-scripts/node-management/taint-nodes.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/pipelines/create-cluster-build-load-apply.sh
+++ b/k8s-scripts/pipelines/create-cluster-build-load-apply.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/k8s-scripts/workload-management/scale-workloads.sh
+++ b/k8s-scripts/workload-management/scale-workloads.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/network-and-connectivity/active-host-scanner.sh
+++ b/network-and-connectivity/active-host-scanner.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/network-and-connectivity/arp-table-viewer.sh
+++ b/network-and-connectivity/arp-table-viewer.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/network-and-connectivity/bandwidth-monitor.sh
+++ b/network-and-connectivity/bandwidth-monitor.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/network-and-connectivity/dns-resolver.sh
+++ b/network-and-connectivity/dns-resolver.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/network-and-connectivity/http-status-code-checker.sh
+++ b/network-and-connectivity/http-status-code-checker.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/network-and-connectivity/ip-extractor-from-log-file.sh
+++ b/network-and-connectivity/ip-extractor-from-log-file.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/network-and-connectivity/network-speed-test.sh
+++ b/network-and-connectivity/network-speed-test.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/network-and-connectivity/ping.sh
+++ b/network-and-connectivity/ping.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/network-and-connectivity/port-scanner.sh
+++ b/network-and-connectivity/port-scanner.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/security-and-access/firewall_configurator.sh
+++ b/security-and-access/firewall_configurator.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/security-and-access/group_access_auditor.sh
+++ b/security-and-access/group_access_auditor.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/security-and-access/malware_scanner.sh
+++ b/security-and-access/malware_scanner.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/security-and-access/password_generator.sh
+++ b/security-and-access/password_generator.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/security-and-access/secure_file_permissions.sh
+++ b/security-and-access/secure_file_permissions.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/security-and-access/ssh_key_manager.sh
+++ b/security-and-access/ssh_key_manager.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/security-and-access/unused_ssh_key_detector.sh
+++ b/security-and-access/unused_ssh_key_detector.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/security-and-access/user_access_auditor.sh
+++ b/security-and-access/user_access_auditor.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/system-scripts/check-process.sh
+++ b/system-scripts/check-process.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/system-scripts/check-updates.sh
+++ b/system-scripts/check-updates.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/system-scripts/cpu-monitor.sh
+++ b/system-scripts/cpu-monitor.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/system-scripts/disk-usage.sh
+++ b/system-scripts/disk-usage.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/system-scripts/monitor-network.sh
+++ b/system-scripts/monitor-network.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/system-scripts/monitor-resources.sh
+++ b/system-scripts/monitor-resources.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/system-scripts/schedule-task.sh
+++ b/system-scripts/schedule-task.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/system-scripts/system-report.sh
+++ b/system-scripts/system-report.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/utils/docker-utils/inspect-resource-docker.sh
+++ b/utils/docker-utils/inspect-resource-docker.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/utils/docker-utils/real_time_container_logs.sh
+++ b/utils/docker-utils/real_time_container_logs.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/utils/generate-ssh-key.sh
+++ b/utils/generate-ssh-key.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/utils/npm/npm-clean-cache.sh
+++ b/utils/npm/npm-clean-cache.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/utils/npm/npm-list-global.sh
+++ b/utils/npm/npm-list-global.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/utils/npm/npm-update-all.sh
+++ b/utils/npm/npm-update-all.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/utils/services-utils/backup-postgresql-compressed.sh
+++ b/utils/services-utils/backup-postgresql-compressed.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/utils/services-utils/backup-postgresql.sh
+++ b/utils/services-utils/backup-postgresql.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/utils/services-utils/restore-postgresql-compressed.sh
+++ b/utils/services-utils/restore-postgresql-compressed.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/utils/services-utils/restore-postgresql.sh
+++ b/utils/services-utils/restore-postgresql.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================


### PR DESCRIPTION
## Summary
- add missing `# shellcheck source=functions/common-init.sh` annotations for scripts sourcing `functions/common-init.sh`

## Testing
- `shellcheck */*.sh */*/*.sh */*/*/*.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883aa1e0ba48325b4082957850e90f6