### PR TITLE
Fix shellcheck issues

### DIFF
--- a/k8s-scripts/node-management/label-nodes.sh
+++ b/k8s-scripts/node-management/label-nodes.sh
@@ -383,7 +383,7 @@ validate_labels() {
   if [[ $valid_count -lt ${#LABELS[@]} ]]; then
     format-echo "WARNING" "Some labels have invalid format"
     if [[ "$FORCE" != true ]]; then
-      read -p "Continue anyway? (y/n): " confirm
+        read -r -p "Continue anyway? (y/n): " confirm
       if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
         format-echo "INFO" "Operation cancelled by user."
         exit 1
@@ -413,9 +413,11 @@ check_label_consistency() {
   
   # Get current labels for all nodes
   for node in "${NODES[@]}"; do
-    echo "Node: $node" >> "$temp_file"
-    kubectl get node "$node" -o jsonpath='{.metadata.labels}' | jq . >> "$temp_file"
-    echo "" >> "$temp_file"
+    {
+      echo "Node: $node"
+      kubectl get node "$node" -o jsonpath='{.metadata.labels}' | jq .
+      echo ""
+    } >> "$temp_file"
   done
   
   #---------------------------------------------------------------------
@@ -465,7 +467,7 @@ check_label_consistency() {
   if [[ "$has_conflicts" == true ]]; then
     format-echo "WARNING" "Label conflicts detected"
     if [[ "$FORCE" != true ]]; then
-      read -p "Continue anyway? (y/n): " confirm
+        read -r -p "Continue anyway? (y/n): " confirm
       if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
         format-echo "INFO" "Operation cancelled by user."
         rm -f "$temp_file"
@@ -833,7 +835,7 @@ main() {
   # Confirm operation if not dry-run or forced
   if [[ "$DRY_RUN" != true && "$FORCE" != true ]]; then
     format-echo "WARNING" "You are about to modify labels on the following nodes: ${NODES[*]}"
-    read -p "Do you want to continue? (y/n): " confirm
+      read -r -p "Do you want to continue? (y/n): " confirm
     if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
       format-echo "INFO" "Operation cancelled by user."
       exit 0

--- a/k8s-scripts/node-management/taint-nodes.sh
+++ b/k8s-scripts/node-management/taint-nodes.sh
@@ -348,7 +348,7 @@ validate_taints() {
   if [[ $valid_count -lt ${#TAINTS[@]} ]]; then
     format-echo "WARNING" "Some taints have invalid format"
     if [[ "$FORCE" != true ]]; then
-      read -p "Continue anyway? (y/n): " confirm
+        read -r -p "Continue anyway? (y/n): " confirm
       if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
         format-echo "INFO" "Operation cancelled by user."
         exit 1
@@ -437,7 +437,7 @@ test_pod_compatibility() {
   if [[ "$has_incompatible" == true ]]; then
     format-echo "WARNING" "Some pods will be evicted when these taints are applied"
     if [[ "$FORCE" != true && "$DRY_RUN" != true ]]; then
-      read -p "Continue anyway? (y/n): " confirm
+        read -r -p "Continue anyway? (y/n): " confirm
       if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
         format-echo "INFO" "Operation cancelled by user."
         exit 1
@@ -725,7 +725,7 @@ main() {
   # Confirm operation if not dry-run or forced
   if [[ "$DRY_RUN" != true && "$FORCE" != true ]]; then
     format-echo "WARNING" "You are about to modify taints on the following nodes: ${NODES[*]}"
-    read -p "Do you want to continue? (y/n): " confirm
+    read -r -p "Do you want to continue? (y/n): " confirm
     if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
       format-echo "INFO" "Operation cancelled by user."
       exit 0

--- a/network-and-connectivity/http-status-code-checker.sh
+++ b/network-and-connectivity/http-status-code-checker.sh
@@ -173,7 +173,7 @@ check_status_codes() {
     # Store headers if requested
     if [[ "$SHOW_HEADERS" == true && -n "$headers" ]]; then
       header_messages+=("$(format-echo "INFO" "Headers for $URL:" 2>&1)")
-      header_messages+=("$(echo "$headers" | sed 's/^/    /')")
+      header_messages+=("    ${headers//$'\n'/$'\n    '}")
     fi
   done
   

--- a/network-and-connectivity/port-scanner.sh
+++ b/network-and-connectivity/port-scanner.sh
@@ -368,10 +368,12 @@ scan_ports() {
   
   # Create or clear output file if specified
   if [ -n "$OUTPUT_FILE" ]; then
-    echo "# Port scan results for $SERVER" > "$OUTPUT_FILE"
-    echo "# Scan started at $(date)" >> "$OUTPUT_FILE"
-    echo "# Port | Status | Service" >> "$OUTPUT_FILE"
-    echo "# ---- | ------ | -------" >> "$OUTPUT_FILE"
+    {
+      echo "# Port scan results for $SERVER"
+      echo "# Scan started at $(date)"
+      echo "# Port | Status | Service"
+      echo "# ---- | ------ | -------"
+    } > "$OUTPUT_FILE"
   fi
   
   local port_count=0
@@ -458,27 +460,29 @@ scan_ports() {
   
   # Append summary to output file if specified
   if [ -n "$OUTPUT_FILE" ]; then
-    echo "" >> "$OUTPUT_FILE"
-    echo "# Summary" >> "$OUTPUT_FILE"
-    echo "# -------" >> "$OUTPUT_FILE"
-    echo "# Server: $SERVER" >> "$OUTPUT_FILE"
-    echo "# Ports scanned: $total_ports" >> "$OUTPUT_FILE"
-    echo "# Open ports found: $open_count" >> "$OUTPUT_FILE"
-    
-    if [ ${#open_ports[@]} -gt 0 ]; then
-      echo -n "# Open ports: " >> "$OUTPUT_FILE"
-      for i in "${!open_ports[@]}"; do
-        if [ "$i" -gt 0 ]; then
-          echo -n ", " >> "$OUTPUT_FILE"
-        fi
-        echo -n "${open_ports[$i]} (${open_services[$i]})" >> "$OUTPUT_FILE"
-      done
-      echo "" >> "$OUTPUT_FILE"
-    else
-      echo "# No open ports found." >> "$OUTPUT_FILE"
-    fi
-    
-    echo "# Scan completed at $(date)" >> "$OUTPUT_FILE"
+    {
+      echo ""
+      echo "# Summary"
+      echo "# -------"
+      echo "# Server: $SERVER"
+      echo "# Ports scanned: $total_ports"
+      echo "# Open ports found: $open_count"
+
+      if [ ${#open_ports[@]} -gt 0 ]; then
+        echo -n "# Open ports: "
+        for i in "${!open_ports[@]}"; do
+          if [ "$i" -gt 0 ]; then
+            echo -n ", "
+          fi
+          echo -n "${open_ports[$i]} (${open_services[$i]})"
+        done
+        echo ""
+      else
+        echo "# No open ports found."
+      fi
+
+      echo "# Scan completed at $(date)"
+    } >> "$OUTPUT_FILE"
   fi
   
   return 0


### PR DESCRIPTION
## Summary
- address shellcheck warnings for k8s label/taint scripts
- fix output redirection style in port scanner
- refine header formatting in HTTP status checker

## Testing
- `./utils/run-shellcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_68863277983483259d68b6905ba8c7a2