### PR TITLE
Fix some shellcheck warnings

### DIFF
--- a/file-scripts/extract-tar.sh
+++ b/file-scripts/extract-tar.sh
@@ -169,7 +169,8 @@ main() {
   
   # List extracted files (top level only)
   format-echo "INFO" "Files extracted:"
-  ls -la "$DEST_DIR" | head -n 20
+  # Use find to safely list files, handling special characters
+  find "$DEST_DIR" -mindepth 1 -maxdepth 1 -exec ls -la {} + | head -n 20
   
   # Show more details if there are many files
   FILE_COUNT=$(find "$DEST_DIR" -type f | wc -l | tr -d ' ')

--- a/network-and-connectivity/dns-resolver.sh
+++ b/network-and-connectivity/dns-resolver.sh
@@ -77,7 +77,6 @@ resolve_domains() {
   echo "----------------------------------------------------------------------------------------"
   
   for DOMAIN in "${DOMAINS[@]}"; do
-    TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S")
     
     # A record (IPv4)
     IPv4=$(dig +short A "$DOMAIN" | head -n 1)

--- a/security-and-access/firewall_configurator.sh
+++ b/security-and-access/firewall_configurator.sh
@@ -199,7 +199,8 @@ apply_firewall_rules() {
   if [ ${#ADDITIONAL_PORTS[@]} -gt 0 ]; then
     format-echo "INFO" "Allowing additional ports..."
     for port in "${ADDITIONAL_PORTS[@]}"; do
-      local service=$(get_service_name "$port")
+      local service
+      service=$(get_service_name "$port")
       if [ "$service" != "Unknown" ]; then
         run_ufw_cmd ufw allow "$port/tcp" comment "$service"
         format-echo "INFO" "Allowed port $port ($service)."
@@ -446,7 +447,8 @@ summarize_rules() {
     if [ ${#ADDITIONAL_PORTS[@]} -gt 0 ]; then
       echo "Additional allowed ports:"
       for port in "${ADDITIONAL_PORTS[@]}"; do
-        local service=$(get_service_name "$port")
+        local service
+        service=$(get_service_name "$port")
         if [ "$service" != "Unknown" ]; then
           echo "- $port ($service)"
         else

--- a/security-and-access/group_access_auditor.sh
+++ b/security-and-access/group_access_auditor.sh
@@ -350,7 +350,7 @@ output_text_format() {
         members="(none)"
       else
         # Replace commas with space-comma-space for better readability
-        members=$(echo "$members" | sed 's/,/, /g')
+        members="${members//,/, }"
       fi
       
       printf "%-20s %-10s %-6s %-40s\n" "$group_name" "$gid" "$sudo_access" "$members"
@@ -388,8 +388,8 @@ output_csv_format() {
       fi
       
       # CSV needs proper escaping - wrap in quotes and escape existing quotes
-      escaped_group_name=$(echo "$group_name" | sed 's/"/""/g')
-      escaped_members=$(echo "$members" | sed 's/"/""/g')
+      escaped_group_name="${group_name//\"/\"\"}"
+      escaped_members="${members//\"/\"\"}"
       
       echo "\"$escaped_group_name\",\"$gid\",\"$escaped_members\",\"$member_count\",\"$sudo_access\""
     done < "$groups_file"
@@ -429,7 +429,7 @@ output_json_format() {
       # Split members string into an array
       local member_array="[]"
       if [[ -n "$members" ]]; then
-        member_array="[\"$(echo "$members" | sed 's/,/","/g')\"]"
+        member_array="[\"${members//,/","}\"]"
       fi
       
       # Add comma separator between entries (except for first)
@@ -478,11 +478,13 @@ output_statistics() {
     print_with_separator "Group Membership Statistics"
     
     # Total groups
-    local total_groups=$(wc -l < "$groups_file")
+    local total_groups
+    total_groups=$(wc -l < "$groups_file")
     echo "Total Groups: $total_groups"
     
     # Empty groups
-    local empty_groups=$(grep -c ':$' "$groups_file" || true)
+    local empty_groups
+    empty_groups=$(grep -c ':$' "$groups_file" || true)
     # Avoid division by zero
     if [ "$total_groups" -gt 0 ]; then
       local empty_percentage=$((empty_groups * 100 / total_groups))
@@ -537,8 +539,10 @@ find_user_in_groups() {
   fi
   
   # Get primary group
-  local primary_gid=$(id -g "$username")
-  local primary_group=$(getent group "$primary_gid" | cut -d: -f1)
+  local primary_gid
+  primary_gid=$(id -g "$username")
+  local primary_group
+  primary_group=$(getent group "$primary_gid" | cut -d: -f1)
   
   echo "User: $username"
   echo "UID: $(id -u "$username")"
@@ -554,7 +558,8 @@ find_user_in_groups() {
       
       # Check sudo access if requested
       if [[ "$SHOW_SUDO_INFO" == "true" ]]; then
-        local sudo_access=$(check_sudo_access "$group_name")
+        local sudo_access
+        sudo_access=$(check_sudo_access "$group_name")
         echo "  Sudo Access: $sudo_access"
       fi
       


### PR DESCRIPTION
## Summary
- address shellcheck warnings in various scripts
- remove unused variable in DNS resolver
- use `find` to list extracted files
- split variable assignments to avoid SC2155
- use parameter expansion instead of `sed` in group access auditor

## Testing
- `shellcheck file-scripts/extract-tar.sh network-and-connectivity/dns-resolver.sh security-and-access/firewall_configurator.sh security-and-access/group_access_auditor.sh`
- `bash -n security-and-access/group_access_auditor.sh`


------
https://chatgpt.com/codex/tasks/task_e_68865743ef0c832590060cae9781dd01