### PR TITLE
Fix terminal width fallback

### DIFF
--- a/shell-scripts.sh
+++ b/shell-scripts.sh
@@ -8,7 +8,7 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Function to display usage instructions with organized folder structure
 usage() {
-    TERMINAL_WIDTH=$(tput cols)
+    TERMINAL_WIDTH=$(tput cols 2>/dev/null || echo 80)
     SEPARATOR=$(printf '%*s' "$TERMINAL_WIDTH" '' | tr ' ' '-')
 
     echo


### PR DESCRIPTION
## Summary
- ensure `usage()` defaults to a width of 80 if `tput` fails

## Testing
- `shellcheck shell-scripts.sh`
- `apt-get update`
- `apt-get install -y shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_68889be7d7488325a02187ce21bcd4a6