### PR TITLE
Fix host_port variable to avoid SC2001

### DIFF
--- a/k8s-scripts/cluster-maintenance/rotate-certs.sh
+++ b/k8s-scripts/cluster-maintenance/rotate-certs.sh
@@ -339,7 +339,7 @@ check_certificate_expiration() {
       # Check the API server certificate
       if [[ -n "$api_server" ]]; then
         local host_port
-        host_port=$(echo "$api_server" | sed 's|https://||')
+        host_port=${api_server#https://}
         
         echo "Certificate Expiration Check:" > "$temp_file"
         echo "---------------------------" >> "$temp_file"
@@ -396,7 +396,7 @@ check_certificate_expiration() {
       # Check the API server certificate
       if [[ -n "$api_server" ]]; then
         local host_port
-        host_port=$(echo "$api_server" | sed 's|https://||')
+        host_port=${api_server#https://}
         
         echo "Certificate Expiration Check:" > "$temp_file"
         echo "---------------------------" >> "$temp_file"


### PR DESCRIPTION
## Summary
- avoid subshell `sed` when parsing kube apiserver URL
- run shellcheck to ensure SC2001 warning cleared

## Testing
- `./utils/run-shellcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_688c86917fb8832583428d21b80d40a6