### PR TITLE
Fix shellcheck source warnings

### DIFF
--- a/development-and-code-management/git/generate-changelog.sh
+++ b/development-and-code-management/git/generate-changelog.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=../../functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/development-and-code-management/git/git-add-commit-push.sh
+++ b/development-and-code-management/git/git-add-commit-push.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=../../functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================

--- a/development-and-code-management/git/git-conflict-finder.sh
+++ b/development-and-code-management/git/git-conflict-finder.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #=====================================================================
 # CONFIGURATION AND DEPENDENCIES
 #=====================================================================
+# shellcheck source=../../functions/common-init.sh
 source "$(dirname "$0")/../../functions/common-init.sh"
 # DEFAULT VALUES
 #=====================================================================


### PR DESCRIPTION
## Summary
- reference common-init.sh for shellcheck

## Testing
- `./utils/run-shellcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_688c869156e08325b0d0f6f2323bebb0