### PR TITLE
Fix shellcheck warning in rotate-certs.sh

### DIFF
--- a/k8s-scripts/cluster-maintenance/rotate-certs.sh
+++ b/k8s-scripts/cluster-maintenance/rotate-certs.sh
@@ -781,7 +781,8 @@ validate_certificates() {
   #---------------------------------------------------------------------
   # Check API server connectivity
   format-echo "INFO" "Checking API server connectivity..."
-  local start_time=$(date +%s)
+  local start_time
+  start_time=$(date +%s)
   local end_time=$((start_time + 60))  # 60 second timeout
   local connected=false
   


### PR DESCRIPTION
## Summary
- fix SC2155 in `rotate-certs.sh`

## Testing
- `./utils/run-shellcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_688c86925e808325a06718f63e865ca2