### PR TITLE
Fix SC2155 warnings in shell scripts

### DIFF
--- a/k8s-scripts/cluster-management/switch-context.sh
+++ b/k8s-scripts/cluster-management/switch-context.sh
@@ -75,8 +75,10 @@ check_requirements() {
 list_contexts() {
   format-echo "INFO" "Listing available Kubernetes contexts..."
   
-  local contexts=($(kubectl config get-contexts -o name))
-  local current_context=$(kubectl config current-context 2>/dev/null || echo "none")
+  local contexts
+  read -r -a contexts <<<"$(kubectl config get-contexts -o name)"
+  local current_context
+  current_context=$(kubectl config current-context 2>/dev/null || echo "none")
   
   if [[ ${#contexts[@]} -eq 0 ]]; then
     format-echo "ERROR" "No Kubernetes contexts found."
@@ -123,7 +125,8 @@ list_contexts() {
     # Exclude non-cluster contexts unless --all is specified
     if [[ "$SHOW_ALL" == false ]]; then
       # Get cluster name for this context
-      local cluster=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"$ctx\")].context.cluster}")
+      local cluster
+      cluster=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"$ctx\")].context.cluster}")
       if [[ -z "$cluster" || "$cluster" == "none" ]]; then
         include=false
       fi
@@ -144,7 +147,8 @@ list_contexts() {
       filtered_providers+=("$provider")
       
       # Get cluster name
-      local cluster=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"$ctx\")].context.cluster}")
+      local cluster
+      cluster=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"$ctx\")].context.cluster}")
       filtered_clusters+=("$cluster")
     fi
   done
@@ -195,7 +199,8 @@ switch_context() {
   fi
   
   # Get current context for comparison
-  local current_context=$(kubectl config current-context 2>/dev/null || echo "none")
+  local current_context
+  current_context=$(kubectl config current-context 2>/dev/null || echo "none")
   
   # Don't switch if already on the target context
   if [[ "$current_context" == "$target_context" ]]; then

--- a/system-scripts/disk-usage.sh
+++ b/system-scripts/disk-usage.sh
@@ -111,11 +111,16 @@ parse_args() {
 # Function to check disk usage for a specific filesystem
 check_fs_usage() {
   local fs="$1"
-  local mount_point=$(df "$fs" | tail -1 | awk '{print $6}')
-  local usage=$(df "$fs" | tail -1 | awk '{print $5}' | sed 's/%//g')
-  local size=$(df -h "$fs" | tail -1 | awk '{print $2}')
-  local used=$(df -h "$fs" | tail -1 | awk '{print $3}')
-  local avail=$(df -h "$fs" | tail -1 | awk '{print $4}')
+  local mount_point
+  mount_point=$(df "$fs" | tail -1 | awk '{print $6}')
+  local usage
+  usage=$(df "$fs" | tail -1 | awk '{print $5}' | sed 's/%//g')
+  local size
+  size=$(df -h "$fs" | tail -1 | awk '{print $2}')
+  local used
+  used=$(df -h "$fs" | tail -1 | awk '{print $3}')
+  local avail
+  avail=$(df -h "$fs" | tail -1 | awk '{print $4}')
   
   if [[ "$VERBOSE" == "true" ]]; then
     format-echo "INFO" "Filesystem: $fs (mounted at $mount_point)"
@@ -152,7 +157,8 @@ check_fs_usage() {
 
 # Function to check all mounted filesystems
 check_all_filesystems() {
-  local fs_list=$(df -t ext2 -t ext3 -t ext4 -t xfs -t btrfs -t hfs -t apfs 2>/dev/null | tail -n +2 | awk '{print $6}' || echo "/")
+  local fs_list
+  fs_list=$(df -t ext2 -t ext3 -t ext4 -t xfs -t btrfs -t hfs -t apfs 2>/dev/null | tail -n +2 | awk '{print $6}' || echo "/")
   
   # On macOS, fallback to simpler approach if the above fails
   if [ -z "$fs_list" ]; then

--- a/system-scripts/monitor-resources.sh
+++ b/system-scripts/monitor-resources.sh
@@ -199,11 +199,16 @@ get_cpu_usage() {
 get_memory_usage() {
   if [[ "$OSTYPE" == "darwin"* ]]; then
     # Improved macOS memory usage calculation using vm_stat and sysctl
-    local total_mem=$(sysctl -n hw.memsize)
-    local page_size=$(vm_stat | grep "page size of" | awk '{print $8}')
-    local active=$(vm_stat | grep "Pages active" | awk '{print $3}' | tr -d '.')
-    local wired=$(vm_stat | grep "Pages wired down" | awk '{print $4}' | tr -d '.')
-    local compressed=$(vm_stat | grep "Pages occupied by compressor" | awk '{print $5}' | tr -d '.')
+    local total_mem
+    total_mem=$(sysctl -n hw.memsize)
+    local page_size
+    page_size=$(vm_stat | grep "page size of" | awk '{print $8}')
+    local active
+    active=$(vm_stat | grep "Pages active" | awk '{print $3}' | tr -d '.')
+    local wired
+    wired=$(vm_stat | grep "Pages wired down" | awk '{print $4}' | tr -d '.')
+    local compressed
+    compressed=$(vm_stat | grep "Pages occupied by compressor" | awk '{print $5}' | tr -d '.')
     local used_mem=$(( (active + wired + compressed) * page_size ))
     local total_mem_mb=$((total_mem / 1024 / 1024))
     local used_mem_mb=$((used_mem / 1024 / 1024))


### PR DESCRIPTION
## Summary
- eliminate inline `local var=$(...)` assignments
- silence SC2155 warnings in monitor, disk usage, and kube context scripts
- keep variable declarations separate from command substitution

## Testing
- `./utils/run-shellcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_688cf2728dd08325bc435fe7f9286e5a